### PR TITLE
additional changes for consistency between ios and android

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -70,7 +70,7 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 
-    implementation "com.namiml:sdk-android:1.0.0"
+    implementation "com.namiml:sdk-android:1.0.1"
 
     implementation 'com.facebook.react:react-native:+'  // From node_modules
 }

--- a/android/src/main/java/com/nami/reactlibrary/NamiEmitter.kt
+++ b/android/src/main/java/com/nami/reactlibrary/NamiEmitter.kt
@@ -81,7 +81,7 @@ class NamiEmitter(reactContext: ReactApplicationContext) :
     ) {
         val map = Arguments.createMap()
         errorString?.let {
-            map.putString("errorDescription", errorString)
+            map.putString("error", errorString)
         }
 
         val resultArray: WritableArray = WritableNativeArray()

--- a/android/src/main/java/com/nami/reactlibrary/NamiUtil.kt
+++ b/android/src/main/java/com/nami/reactlibrary/NamiUtil.kt
@@ -32,8 +32,9 @@ fun FormattedSku.toFormattedSkuDict(): WritableMap {
 fun NamiPaywall.toNamiPaywallDict(): WritableMap {
 
     val paywallMap: WritableMap = Arguments.createMap()
-    paywallMap.putString("title", title.orEmpty())
-    paywallMap.putString("body", body.orEmpty())
+    // These don't seem to exist, inconsistent between Android and iOS, leave in marketing content
+    //paywallMap.putString("title", title.orEmpty())
+    //paywallMap.putString("body", body.orEmpty())
 
     val marketingContentMap = Arguments.createMap()
     marketingContentMap.putString("title", title.orEmpty())
@@ -77,6 +78,9 @@ fun NamiPaywall.toNamiPaywallDict(): WritableMap {
     }
 
     paywallMap.putBoolean("use_bottom_overlay", useBottomOverlay)
+
+    // remove key that in not available on iOS
+    paywallMap.remove("style")
 
     return paywallMap
 }

--- a/android/src/main/java/com/nami/reactlibrary/NamiUtil.kt
+++ b/android/src/main/java/com/nami/reactlibrary/NamiUtil.kt
@@ -24,7 +24,7 @@ import java.util.TimeZone
 
 fun FormattedSku.toFormattedSkuDict(): WritableMap {
     val map: WritableMap = Arguments.createMap()
-    map.putString("id", this.id)
+    map.putString("sku_ref_id", this.sku_ref_id)
     map.putBoolean("featured", this.featured)
     return map
 }

--- a/android/src/main/java/com/nami/reactlibrary/NamiUtil.kt
+++ b/android/src/main/java/com/nami/reactlibrary/NamiUtil.kt
@@ -24,7 +24,7 @@ import java.util.TimeZone
 
 fun FormattedSku.toFormattedSkuDict(): WritableMap {
     val map: WritableMap = Arguments.createMap()
-    map.putString("sku_ref_id", this.sku_ref_id)
+    map.putString("sku_ref_id", this.skuRefId)
     map.putBoolean("featured", this.featured)
     return map
 }

--- a/android/src/main/java/com/nami/reactlibrary/NamiUtil.kt
+++ b/android/src/main/java/com/nami/reactlibrary/NamiUtil.kt
@@ -79,9 +79,6 @@ fun NamiPaywall.toNamiPaywallDict(): WritableMap {
 
     paywallMap.putBoolean("use_bottom_overlay", useBottomOverlay)
 
-    // remove key that in not available on iOS
-    paywallMap.remove("style")
-
     return paywallMap
 }
 

--- a/ios/NamiBridgeUtil.h
+++ b/ios/NamiBridgeUtil.h
@@ -23,6 +23,8 @@
 
 + (NSDictionary<NSString *,NSString *> *) paywallStylingToPaywallStylingDict:(PaywallStyleData *)styling;
 
++ (NSArray *)stripPresentationPositionFromOrderedMetadataForPaywallMetaDict: (NSDictionary *)paywallMeta;
+
 + (NSString *)hexStringForColor:(UIColor *)color;
 
 @end

--- a/ios/NamiBridgeUtil.m
+++ b/ios/NamiBridgeUtil.m
@@ -100,6 +100,22 @@
      return purchaseDict;
  }
 
+
+// Strip out presention_position from all listed sku items in the sku_ordered_metadata array
++ (NSArray *)stripPresentationPositionFromOrderedMetadataForPaywallMetaDict: (NSDictionary *)paywallMeta {
+    NSArray *baseSkuArray = [paywallMeta objectForKey:@"sku_ordered_metadata"];
+    NSMutableArray *newOrderedMetadata = [NSMutableArray new];
+    
+    if ( [baseSkuArray isKindOfClass:[NSArray class]] ) {
+        for (NSDictionary *baseSkuDict in baseSkuArray) {
+            NSMutableDictionary *skuFormattingDict = [NSMutableDictionary dictionaryWithDictionary:baseSkuDict];
+            [skuFormattingDict removeObjectForKey:@"presentation_position"];
+            [newOrderedMetadata addObject:skuFormattingDict];
+        }
+    }
+    return newOrderedMetadata;
+}
+
 + (NSDictionary<NSString *,NSString *> *) entitlementToEntitlementDict:(NamiEntitlement *)entitlement {
     NSMutableDictionary<NSString *,id> *entitlementDict = [NSMutableDictionary new];
     NSLog(@"Converting entitlement %@", entitlement);

--- a/ios/NamiEmitter.m
+++ b/ios/NamiEmitter.m
@@ -199,9 +199,11 @@ bool hasNamiEmitterListeners;
         
         NSMutableDictionary *paywallMeta = [NSMutableDictionary dictionaryWithDictionary:paywallMetadata.namiPaywallInfoDict];
         // This part is really meant to be internally facing, scrub from dictionary
-        NSMutableDictionary *skuFormattingDict = [NSMutableDictionary dictionaryWithDictionary:[paywallMeta objectForKey:@"sku_ordered_metadata"]];
-        [skuFormattingDict removeObjectForKey:@"presentation_position"];
-        [paywallMeta setObject:skuFormattingDict  forKey:@"formatted_skus"];
+
+        // Strip out presention_position from all listed sku items
+        NSArray *cleanedOrderdMetadata = [NamiBridgeUtil stripPresentationPositionFromOrderedMetadataForPaywallMetaDict:paywallMeta];
+        [paywallMeta setObject:cleanedOrderdMetadata  forKey:@"formatted_skus"];
+
         [paywallMeta removeObjectForKey:@"sku_ordered_metadata"];
         [paywallMeta removeObjectForKey:@"skus"];
 
@@ -224,9 +226,10 @@ bool hasNamiEmitterListeners;
     if (hasNamiEmitterListeners) {
         NSMutableDictionary *paywallMeta = [NSMutableDictionary dictionary];
         
-        NSMutableDictionary *skuFormattingDict = [NSMutableDictionary dictionaryWithDictionary:[paywallMeta objectForKey:@"sku_ordered_metadata"]];
-        [skuFormattingDict removeObjectForKey:@"presentation_position"];
-        [paywallMeta setObject:skuFormattingDict  forKey:@"formatted_skus"];
+        // Strip out presention_position from all listed sku items
+        NSArray *cleanedOrderdMetadata = [NamiBridgeUtil stripPresentationPositionFromOrderedMetadataForPaywallMetaDict:paywallMeta];
+        [paywallMeta setObject:cleanedOrderdMetadata  forKey:@"formatted_skus"];
+        
         [paywallMeta removeObjectForKey:@"sku_ordered_metadata"];
         [paywallMeta removeObjectForKey:@"skus"];
         

--- a/ios/NamiEmitter.m
+++ b/ios/NamiEmitter.m
@@ -209,6 +209,7 @@ bool hasNamiEmitterListeners;
         // remove keys that are inconsistent with android 
         [paywallMeta removeObjectForKey:@"body"];
         [paywallMeta removeObjectForKey:@"title"];
+        [paywallMeta removeObjectForKey:@"style"]
 
         [self sendEventWithName:@"AppPaywallActivate" body:@{ @"skus": skuDicts,
                                                             @"developerPaywallID": developerPaywallID,

--- a/ios/NamiEmitter.m
+++ b/ios/NamiEmitter.m
@@ -199,7 +199,8 @@ bool hasNamiEmitterListeners;
         
         NSMutableDictionary *paywallMeta = [NSMutableDictionary dictionaryWithDictionary:paywallMetadata.namiPaywallInfoDict];
         // This part is really meant to be internally facing, scrub from dictionary
-        // [paywallMeta removeObjectForKey:@"formatted_skus"];
+        // [paywallMeta removeObjectForKey:@"formatted_skus"]; // this seems to have no effect
+        [paywallMeta setObject: [paywallMeta objectForKey:@"sku_ordered_metadata"] forKey:@"formatted_skus"];
         [paywallMeta removeObjectForKey:@"sku_ordered_metadata"];
         [paywallMeta removeObjectForKey:@"skus"];
 

--- a/ios/NamiEmitter.m
+++ b/ios/NamiEmitter.m
@@ -170,7 +170,7 @@ bool hasNamiEmitterListeners;
         sendDict[@"purchases"] =  convertedPurchaseDicts;
         sendDict[@"purchaseState"] = convertedState;
         if (localizedErrorDescription != nil) {
-           sendDict[@"errorDescription"] = localizedErrorDescription;
+           sendDict[@"error"] = localizedErrorDescription;
         }
         
         [self sendEventWithName:@"PurchasesChanged" body:sendDict];
@@ -199,8 +199,9 @@ bool hasNamiEmitterListeners;
         
         NSMutableDictionary *paywallMeta = [NSMutableDictionary dictionaryWithDictionary:paywallMetadata.namiPaywallInfoDict];
         // This part is really meant to be internally facing, scrub from dictionary
-        // [paywallMeta removeObjectForKey:@"formatted_skus"]; // this seems to have no effect
-        [paywallMeta setObject: [paywallMeta objectForKey:@"sku_ordered_metadata"] forKey:@"formatted_skus"];
+        NSMutableDictionary *skuFormattingDict = [NSMutableDictionary dictionaryWithDictionary:[paywallMeta objectForKey:@"sku_ordered_metadata"]];
+        [skuFormattingDict removeObjectForKey:@"presentation_position"];
+        [paywallMeta setObject:skuFormattingDict  forKey:@"formatted_skus"];
         [paywallMeta removeObjectForKey:@"sku_ordered_metadata"];
         [paywallMeta removeObjectForKey:@"skus"];
 
@@ -222,8 +223,12 @@ bool hasNamiEmitterListeners;
     // Let system know a blocking paywall has been closed, in case they want to react specifically.
     if (hasNamiEmitterListeners) {
         NSMutableDictionary *paywallMeta = [NSMutableDictionary dictionary];
-        // This part is really meant to be internally facing, scrub from dictionary
-        [paywallMeta removeObjectForKey:@"formatted_skus"];
+        
+        NSMutableDictionary *skuFormattingDict = [NSMutableDictionary dictionaryWithDictionary:[paywallMeta objectForKey:@"sku_ordered_metadata"]];
+        [skuFormattingDict removeObjectForKey:@"presentation_position"];
+        [paywallMeta setObject:skuFormattingDict  forKey:@"formatted_skus"];
+        [paywallMeta removeObjectForKey:@"sku_ordered_metadata"];
+        [paywallMeta removeObjectForKey:@"skus"];
         
         [self sendEventWithName:@"BlockingPaywallClosed" body:@{ @"blockingPaywallClosed": @(true)}];
     }

--- a/ios/NamiEmitter.m
+++ b/ios/NamiEmitter.m
@@ -199,11 +199,17 @@ bool hasNamiEmitterListeners;
         
         NSMutableDictionary *paywallMeta = [NSMutableDictionary dictionaryWithDictionary:paywallMetadata.namiPaywallInfoDict];
         // This part is really meant to be internally facing, scrub from dictionary
-        [paywallMeta removeObjectForKey:@"formatted_skus"];
+        // [paywallMeta removeObjectForKey:@"formatted_skus"];
+        [paywallMeta removeObjectForKey:@"sku_ordered_metadata"]
         [paywallMeta removeObjectForKey:@"skus"];
+
         NSDictionary *paywallStylingDict = [NamiBridgeUtil paywallStylingToPaywallStylingDict:[paywallMetadata styleData]];
         paywallMeta[@"styleData"] = paywallStylingDict;
         
+        // remove keys that are inconsistent with android 
+        [paywallMeta removeObjectForKey:@"body"];
+        [paywallMeta removeObjectForKey:@"title"];
+
         [self sendEventWithName:@"AppPaywallActivate" body:@{ @"skus": skuDicts,
                                                             @"developerPaywallID": developerPaywallID,
                                                             @"paywallMetadata": paywallMeta }];

--- a/ios/NamiEmitter.m
+++ b/ios/NamiEmitter.m
@@ -45,7 +45,7 @@ RCT_EXTERN_METHOD(getPurchasedProducts: (RCTResponseSenderBlock)callback)
             [self sendSignInActivateFromVC:fromVC forPaywall:developerPaywallID paywallMetadata:paywallMetadata];
         }];
         
-        [NamiPaywallManager registerPaywallHandler:^(UIViewController * _Nullable fromVC, NSArray<NamiSKU *> * _Nullable products, NSString * _Nonnull developerPaywallID, NamiPaywall * _Nonnull paywallMetadata) {
+        [NamiPaywallManager registerPaywallRaiseHandler:^(UIViewController * _Nullable fromVC, NSArray<NamiSKU *> * _Nullable products, NSString * _Nonnull developerPaywallID, NamiPaywall * _Nonnull paywallMetadata) {
             [self sendPaywallActivatedFromVC:fromVC forPaywall:developerPaywallID withProducts:products paywallMetadata:paywallMetadata];
         }];
         
@@ -200,7 +200,7 @@ bool hasNamiEmitterListeners;
         NSMutableDictionary *paywallMeta = [NSMutableDictionary dictionaryWithDictionary:paywallMetadata.namiPaywallInfoDict];
         // This part is really meant to be internally facing, scrub from dictionary
         // [paywallMeta removeObjectForKey:@"formatted_skus"];
-        [paywallMeta removeObjectForKey:@"sku_ordered_metadata"]
+        [paywallMeta removeObjectForKey:@"sku_ordered_metadata"];
         [paywallMeta removeObjectForKey:@"skus"];
 
         NSDictionary *paywallStylingDict = [NamiBridgeUtil paywallStylingToPaywallStylingDict:[paywallMetadata styleData]];
@@ -209,7 +209,7 @@ bool hasNamiEmitterListeners;
         // remove keys that are inconsistent with android 
         [paywallMeta removeObjectForKey:@"body"];
         [paywallMeta removeObjectForKey:@"title"];
-        [paywallMeta removeObjectForKey:@"style"]
+        [paywallMeta removeObjectForKey:@"style"];
 
         [self sendEventWithName:@"AppPaywallActivate" body:@{ @"skus": skuDicts,
                                                             @"developerPaywallID": developerPaywallID,

--- a/ios/NamiPaywallManagerBridge.m
+++ b/ios/NamiPaywallManagerBridge.m
@@ -29,7 +29,7 @@
     self = [super init];
     if (self) {
         [self setBlockPaywallRaise:false];
-        [NamiPaywallManager registerAutoRaisePaywallBlocker:^BOOL{
+        [NamiPaywallManager registerAllowAutoRaisePaywallHandler:^BOOL{
             NSLog(@"Block paywall raise set to %d", [self blockPaywallRaise]);
             return ![self blockPaywallRaise];
         }];
@@ -87,8 +87,8 @@ RCT_EXPORT_METHOD(fetchCustomPaywallMetaForDeveloperID:(NSString *)developerPayw
         
         
         NSArray *wrapperArray = @[@{ @"products": productDicts,
-                                                                @"developerPaywallID": developerPaywallID,
-                                                                @"paywallMetadata": paywallMeta }];
+                                     @"developerPaywallID": developerPaywallID,
+                                     @"paywallMetadata": paywallMeta }];
         completion(wrapperArray);
     }];
 }

--- a/ios/NamiPaywallManagerBridge.m
+++ b/ios/NamiPaywallManagerBridge.m
@@ -81,9 +81,12 @@ RCT_EXPORT_METHOD(fetchCustomPaywallMetaForDeveloperID:(NSString *)developerPayw
         NSMutableDictionary *paywallMeta = [NSMutableDictionary dictionaryWithDictionary:paywallMetadata.namiPaywallInfoDict];
         // This part is really meant to be internally facing, scrub from dictionary
         
-        NSMutableDictionary *skuFormattingDict = [NSMutableDictionary dictionaryWithDictionary:[paywallMeta objectForKey:@"sku_ordered_metadata"]];
-        [skuFormattingDict removeObjectForKey:@"presentation_position"];
-        [paywallMeta setObject:skuFormattingDict  forKey:@"formatted_skus"];
+        NSDictionary *baseSkuDict = [paywallMeta objectForKey:@"sku_ordered_metadata"];
+        
+        // Strip out presention_position from all listed sku items
+        NSArray *cleanedOrderdMetadata = [NamiBridgeUtil stripPresentationPositionFromOrderedMetadataForPaywallMetaDict:paywallMeta];        
+        [paywallMeta setObject:cleanedOrderdMetadata  forKey:@"formatted_skus"];
+        
         [paywallMeta removeObjectForKey:@"sku_ordered_metadata"];
         [paywallMeta removeObjectForKey:@"skus"];
 

--- a/ios/NamiPaywallManagerBridge.m
+++ b/ios/NamiPaywallManagerBridge.m
@@ -80,8 +80,13 @@ RCT_EXPORT_METHOD(fetchCustomPaywallMetaForDeveloperID:(NSString *)developerPayw
 
         NSMutableDictionary *paywallMeta = [NSMutableDictionary dictionaryWithDictionary:paywallMetadata.namiPaywallInfoDict];
         // This part is really meant to be internally facing, scrub from dictionary
-        [paywallMeta removeObjectForKey:@"formatted_skus"];
+        
+        NSMutableDictionary *skuFormattingDict = [NSMutableDictionary dictionaryWithDictionary:[paywallMeta objectForKey:@"sku_ordered_metadata"]];
+        [skuFormattingDict removeObjectForKey:@"presentation_position"];
+        [paywallMeta setObject:skuFormattingDict  forKey:@"formatted_skus"];
+        [paywallMeta removeObjectForKey:@"sku_ordered_metadata"];
         [paywallMeta removeObjectForKey:@"skus"];
+
         NSDictionary *paywallStylingDict = [NamiBridgeUtil paywallStylingToPaywallStylingDict:[paywallMetadata styleData]];
         paywallMeta[@"styleData"] = paywallStylingDict;
         

--- a/ios/NamiPaywallManagerBridge.m
+++ b/ios/NamiPaywallManagerBridge.m
@@ -42,7 +42,7 @@ RCT_EXTERN_METHOD(raisePaywall)
   [NamiPaywallManager raisePaywallFromVC:nil];
 }
 
-RCT_EXPORT_METHOD(raisePaywallByDeveloperPaywallID:(NSString * _Nonnull) developerPaywallID)
+RCT_EXPORT_METHOD(raisePaywallByDeveloperPaywallId:(NSString * _Nonnull) developerPaywallID)
 {
     [NamiPaywallManager raisePaywallWithDeveloperPaywallID:developerPaywallID fromVC:nil];
 }

--- a/ios/NamiPurchaseManagerBridge.m
+++ b/ios/NamiPurchaseManagerBridge.m
@@ -55,7 +55,7 @@ RCT_EXPORT_METHOD(restorePurchases:(RCTResponseSenderBlock)completion)
         NSString *errorDesc = [error localizedDescription];
         NSDictionary *retDict;
         if ([errorDesc length] > 0) {
-           retDict = @{@"success": [NSNumber numberWithBool:success], @"errorDescription": [error localizedDescription]};
+           retDict = @{@"success": [NSNumber numberWithBool:success], @"error": [error localizedDescription]};
         } else {
             retDict = @{@"success": [NSNumber numberWithBool:success]};
         }


### PR DESCRIPTION
- fix naming of callback for `AllowPaywallAutoRaise`
- consistent key name for error on `restorePurchases` call
- changes for consistency on payload returned by `AppPaywallActivate` event