### PR TITLE
2.0.0 - Update IOS Bridge to Nami SDK 2.9.3

### DIFF
--- a/examples/Analytics/ios/Podfile
+++ b/examples/Analytics/ios/Podfile
@@ -1,4 +1,4 @@
-platform :ios, '11.0'
+platform :ios, '11.2'
 require_relative '../node_modules/@react-native-community/cli-platform-ios/native_modules'
 
 target 'Analytics' do

--- a/examples/Analytics/package.json
+++ b/examples/Analytics/package.json
@@ -20,7 +20,7 @@
     "react": "17.0.1",
     "react-native": "0.63.3",
     "react-native-gesture-handler": "^1.5.3",
-    "react-native-nami-sdk": "^1.3.0",
+    "react-native-nami-sdk": "^2.0.0",
     "react-native-reanimated": "^1.7.0",
     "react-native-safe-area-context": "^3.1.8",
     "react-native-screens": "^2.0.0-alpha.32",

--- a/examples/Analytics/package.json
+++ b/examples/Analytics/package.json
@@ -20,7 +20,7 @@
     "react": "17.0.1",
     "react-native": "0.63.3",
     "react-native-gesture-handler": "^1.5.3",
-    "react-native-nami-sdk": "^1.2.1",
+    "react-native-nami-sdk": "^1.3.0",
     "react-native-reanimated": "^1.7.0",
     "react-native-safe-area-context": "^3.1.8",
     "react-native-screens": "^2.0.0-alpha.32",

--- a/examples/Basic/ios/Podfile
+++ b/examples/Basic/ios/Podfile
@@ -1,4 +1,4 @@
-platform :ios, '11.0'
+platform :ios, '11.2'
 require_relative '../node_modules/@react-native-community/cli-platform-ios/native_modules'
 
 target 'Basic' do

--- a/examples/Basic/package.json
+++ b/examples/Basic/package.json
@@ -18,7 +18,7 @@
     "react": "17.0.1",
     "react-native": "0.63.3",
     "react-native-gesture-handler": "^1.5.3",
-    "react-native-nami-sdk": "^1.2.1",
+    "react-native-nami-sdk": "^1.3.0",
     "react-native-reanimated": "^1.7.0",
     "react-native-safe-area-context": "^3.1.8",
     "react-native-screens": "^2.0.0-alpha.32",

--- a/examples/Basic/package.json
+++ b/examples/Basic/package.json
@@ -18,7 +18,7 @@
     "react": "17.0.1",
     "react-native": "0.63.3",
     "react-native-gesture-handler": "^1.5.3",
-    "react-native-nami-sdk": "^1.3.0",
+    "react-native-nami-sdk": "^2.0.0",
     "react-native-reanimated": "^1.7.0",
     "react-native-safe-area-context": "^3.1.8",
     "react-native-screens": "^2.0.0-alpha.32",

--- a/examples/BasicLinkedPaywall/components/LinkedPaywall/LinkedPaywall.js
+++ b/examples/BasicLinkedPaywall/components/LinkedPaywall/LinkedPaywall.js
@@ -16,12 +16,12 @@ const LinkedPaywall = (props) => {
   const {open, setOpen, data} = props;
   const {title, body} = data.paywallMetadata.marketing_content;
   const {background_image_url_phone} = data.paywallMetadata;
-  const {skus} = data;
+  const {skus} = data.namiSkus;
 
   const restore = () => {
     NativeModules.NamiPurchaseManagerBridge.restorePurchases((result) => {
       console.log('ExampleApp: Nami restorePurchases results was ', result);
-      if (result.success) {
+      if (result.state == 1) {
         NativeModules.NamiPurchaseManagerBridge.purchases((resultInside) => {
           console.log('ExampleApp: Nami purchases are ', resultInside);
           console.log('Purchase count is ', resultInside.length);
@@ -41,7 +41,7 @@ const LinkedPaywall = (props) => {
             );
           }
         });
-      } else {
+      } else if (result.state == 2) {
         Alert.alert(
           'Restore Failed',
           'Restore failed to complete.',

--- a/examples/BasicLinkedPaywall/ios/Podfile
+++ b/examples/BasicLinkedPaywall/ios/Podfile
@@ -1,4 +1,4 @@
-platform :ios, '11.0'
+platform :ios, '11.2'
 require_relative '../node_modules/@react-native-community/cli-platform-ios/native_modules'
 
 target 'BasicLinkedPaywall' do

--- a/examples/BasicLinkedPaywall/package.json
+++ b/examples/BasicLinkedPaywall/package.json
@@ -18,7 +18,7 @@
     "react": "17.0.1",
     "react-native": "0.63.3",
     "react-native-gesture-handler": "^1.5.3",
-    "react-native-nami-sdk": "1.2.1",
+    "react-native-nami-sdk": "^1.3.0",
     "react-native-reanimated": "^1.7.0",
     "react-native-safe-area-context": "^3.1.8",
     "react-native-screens": "^2.0.0-alpha.32",

--- a/examples/BasicLinkedPaywall/package.json
+++ b/examples/BasicLinkedPaywall/package.json
@@ -18,7 +18,7 @@
     "react": "17.0.1",
     "react-native": "0.63.3",
     "react-native-gesture-handler": "^1.5.3",
-    "react-native-nami-sdk": "^1.3.0",
+    "react-native-nami-sdk": "^2.0.0",
     "react-native-reanimated": "^1.7.0",
     "react-native-safe-area-context": "^3.1.8",
     "react-native-screens": "^2.0.0-alpha.32",

--- a/ios/Nami.m
+++ b/ios/Nami.m
@@ -39,6 +39,12 @@ RCT_EXPORT_METHOD(configure: (NSDictionary *)configDict) {
             config.logLevel = NamiLogLevelDebug;
         }
         
+        NSString *languageString = configDict[@"namiLanguageCode"];
+        if ([logLevelString length] > 0) {
+            NSLog(@"Nami language code from dictionary is %@", languageString);
+            config.namiLanguageCode = languageString;
+        }
+        
         NSObject *bypassString = configDict[@"bypassStore"];
         if ( bypassString != NULL )
         {

--- a/ios/Nami.m
+++ b/ios/Nami.m
@@ -76,7 +76,7 @@ RCT_EXPORT_METHOD(configure: (NSDictionary *)configDict) {
         }
         
         // Start commands with header iformation for Nami to let them know this is a React client.
-        NSMutableArray *namiCommandStrings = [NSMutableArray arrayWithArray:@[@"extendedClientInfo:react-native:1.2.1"]];
+        NSMutableArray *namiCommandStrings = [NSMutableArray arrayWithArray:@[@"extendedClientInfo:react-native:2.0.0"]];
         
         // Add additional namiCommands app may have sent in.
         NSObject *appCommandStrings = configDict[@"namiCommands"];

--- a/ios/NamiEmitter.m
+++ b/ios/NamiEmitter.m
@@ -259,7 +259,7 @@ bool hasNamiEmitterListeners;
         [paywallMeta removeObjectForKey:@"title"];
         [paywallMeta removeObjectForKey:@"style"];
 
-        [self sendEventWithName:@"AppPaywallActivate" body:@{ @"skus": skuDicts,
+        [self sendEventWithName:@"AppPaywallActivate" body:@{ @"namiSkus": skuDicts,
                                                             @"developerPaywallID": developerPaywallID,
                                                             @"paywallMetadata": paywallMeta }];
   }

--- a/ios/NamiPaywallManagerBridge.m
+++ b/ios/NamiPaywallManagerBridge.m
@@ -95,7 +95,7 @@ RCT_EXPORT_METHOD(fetchCustomPaywallMetaForDeveloperID:(NSString *)developerPayw
         paywallMeta[@"styleData"] = paywallStylingDict;
         
         
-        NSArray *wrapperArray = @[@{ @"products": productDicts,
+        NSArray *wrapperArray = @[@{ @"namiSkus": productDicts,
                                      @"developerPaywallID": developerPaywallID,
                                      @"paywallMetadata": paywallMeta }];
         completion(wrapperArray);

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -1,11 +1,11 @@
-platform :ios, '11.0'
+platform :ios, '11.2'
 require_relative '../node_modules/@react-native-community/cli-platform-ios/native_modules'
 
 source 'https://cdn.cocoapods.org/'
 
 target 'RNNami' do
   # Pods for RNNami
-  pod 'Nami', '2.7.0'
+  pod 'Nami', '2.9.3'
   pod 'FBLazyVector', :path => "../node_modules/react-native/Libraries/FBLazyVector"
   pod 'FBReactNativeSpec', :path => "../node_modules/react-native/Libraries/FBReactNativeSpec"
   pod 'RCTRequired', :path => "../node_modules/react-native/Libraries/RCTRequired"

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -60,4 +60,23 @@ post_install do |installer|
       end
     end
   end
+       ## Fix for XCode 12+, hotpatch of react files should be a great idea
+      find_and_replace("../node_modules/react-native/React/CxxBridge/RCTCxxBridge.mm",
+      "_initializeModules:(NSArray<id<RCTBridgeModule>> *)modules", "_initializeModules:(NSArray<Class> *)modules")
+      find_and_replace("../node_modules/react-native/ReactCommon/turbomodule/core/platform/ios/RCTTurboModuleManager.mm",
+      "RCTBridgeModuleNameForClass(module))", "RCTBridgeModuleNameForClass(Class(module)))")
+end
+
+
+def find_and_replace(dir, findstr, replacestr)
+  Dir[dir].each do |name|
+      text = File.read(name)
+      replace = text.gsub(findstr,replacestr)
+      if text != replace
+          puts "Fix: " + name
+          File.open(name, "w") { |file| file.puts replace }
+          STDOUT.flush
+      end
+  end
+  Dir[dir + '*/'].each(&method(:find_and_replace))
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-nami-sdk",
-  "version": "1.3.0,
+  "version": "1.3.0",
   "description": "React Native Module for Nami - The Smartest Way to Sell Subscriptions.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-nami-sdk",
-  "version": "1.3.0",
+  "version": "2.0.0",
   "description": "React Native Module for Nami - The Smartest Way to Sell Subscriptions.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-nami-sdk",
-  "version": "1.2.1",
+  "version": "1.3.0,
   "description": "React Native Module for Nami - The Smartest Way to Sell Subscriptions.",
   "main": "index.js",
   "scripts": {

--- a/react-native-nami-sdk.podspec
+++ b/react-native-nami-sdk.podspec
@@ -13,12 +13,12 @@ Pod::Spec.new do |s|
   s.homepage     = package['homepage']
   s.license      = package['license']
 
-  s.platform     = :ios, "11.0"
+  s.platform     = :ios, "11.2"
   s.source       = { :git => "https://github.com/namiml/react-native-nami-sdk.git", :tag => "#{s.version}" }
   s.source_files = "ios/**/*.{h,m}"
   s.requires_arc = true
 
-  s.dependency 'Nami', '2.7.0'
+  s.dependency 'Nami', '2.9.3'
   s.dependency 'React'
 
 end


### PR DESCRIPTION
# Changelog

iOS release v2.0.0 for React Native.

Updates Nami Apple SDK to v2.9.3.

Apple SDK release notes available [here](https://github.com/namiml/nami-apple/releases).

## Breaking Changes

- Changes restore purchases callback to use new form that reports state of restore purchase request instead of success flag.
- UI elements presented by the Nami Apple SDK about the execution of a restore purchase process is now the responsibility of the app using the `registerRestorePurchasesHandler` callback
- Changes paywall callbacks (linked paywall and paywall meta data for developer ID) to present skus in dictionary as "namiSkus" to reflect NamiPaywall object, was "skus".
- Updated sample apps to reflect new 11.2 minimum iOS requirement (was 11.0).
- Removed all UI modals on Apple that communicate changes related to the purchase process (success and failure) produced by Nami, leaving only Apple system messages 

## New Features

- Adds the ability to localize paywalls
- Introduces parameter `namiLanguageCode` to the `NamiConfiguration` object to set the language of the paywall you wish to display

## Enhancements

- Improved how the Paywall Creator handles large elements on paywalls to ensure no elements overlap
- Added support for simulators running on M1 processors

## Bugfixes

- Fixed issue where paywall opened in landscape orientation does not properly render when switched to portrait orientation.

## Maintenance

- Add update script to pod file post-install for iOS to fix compilation errors in react library.


