### PR TITLE
Bugfix: Android Launch Context

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -84,7 +84,7 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
 
     implementation 'com.github.jeziellago:compose-markdown:0.3.0'
-    implementation "com.namiml:sdk-android:3.0.23"
+    implementation "com.namiml:sdk-android:3.0.24"
 
     implementation 'com.facebook.react:react-native:+'  // From node_modules
     coreLibraryDesugaring "com.android.tools:desugar_jdk_libs:1.1.5"

--- a/android/src/main/java/com/nami/reactlibrary/NamiCampaignManagerBridge.kt
+++ b/android/src/main/java/com/nami/reactlibrary/NamiCampaignManagerBridge.kt
@@ -57,7 +57,6 @@ class NamiCampaignManagerBridgeModule(reactContext: ReactApplicationContext) :
 
         var paywallLaunchContext: PaywallLaunchContext? = null
         if (context != null) {
-
             val productGroups: MutableList<String> = mutableListOf()
             val customAttributes: MutableMap<String, String> = mutableMapOf()
 
@@ -69,7 +68,6 @@ class NamiCampaignManagerBridgeModule(reactContext: ReactApplicationContext) :
                         if (groupString != null) {
                             productGroups.add(groupString)
                         }
-
                     }
                 }
                 Log.d(LOG_TAG, "productGroups $productGroups")
@@ -87,7 +85,12 @@ class NamiCampaignManagerBridgeModule(reactContext: ReactApplicationContext) :
                 }
             }
 
-            paywallLaunchContext = PaywallLaunchContext(productGroups.toList(), customAttributes)
+            if (context.hasKey("productGroups")) {
+                paywallLaunchContext = PaywallLaunchContext(productGroups.toList(), customAttributes)
+            } else {
+                paywallLaunchContext = PaywallLaunchContext(null, customAttributes)
+            }
+
         }
 
         if (theActivity != null) {

--- a/examples/Basic/containers/CampaignScreen.tsx
+++ b/examples/Basic/containers/CampaignScreen.tsx
@@ -95,13 +95,10 @@ const CampaignScreen: FC<CampaignScreenProps> = ({navigation}) => {
   }, []);
 
   const triggerLaunch = (label?: any, url?: any) => {
-    // const paywallLaunchContext = {
-    //   productGroups: ['group1'],
-    // };
     return NamiCampaignManager.launch(
       label,
       url,
-      undefined,
+      {},
       (successAction, error) => {
         console.log('successAction', successAction);
         console.log('error', error);


### PR DESCRIPTION
- If a `productsGroup` key was not passed into PaywallLaunchContext, and empty `[]` product group set was passed to the native layer
- Bump android dependency to `3.0.24`