### PR TITLE
3.0.31

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -84,7 +84,7 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
 
     implementation 'com.github.jeziellago:compose-markdown:0.3.0'
-    compileOnly "com.namiml:sdk-amazon:3.1.5"
+    compileOnly "com.namiml:sdk-amazon:3.1.7"
 
     implementation 'com.facebook.react:react-native:+'  // From node_modules
     coreLibraryDesugaring "com.android.tools:desugar_jdk_libs:1.1.5"

--- a/android/src/main/java/com/nami/reactlibrary/NamiBridgeModule.kt
+++ b/android/src/main/java/com/nami/reactlibrary/NamiBridgeModule.kt
@@ -115,7 +115,7 @@ class NamiBridgeModule(reactContext: ReactApplicationContext) :
             } else {
                 Arguments.createArray()
             }
-        val settingsList = mutableListOf("extendedClientInfo:react-native:3.0.30")
+        val settingsList = mutableListOf("extendedClientInfo:react-native:3.0.31")
         namiCommandsReact?.toArrayList()?.filterIsInstance<String>()?.let { commandsFromReact ->
             settingsList.addAll(commandsFromReact)
         }

--- a/android/src/main/java/com/nami/reactlibrary/NamiPaywallManagerBridgeModule.kt
+++ b/android/src/main/java/com/nami/reactlibrary/NamiPaywallManagerBridgeModule.kt
@@ -236,6 +236,18 @@ class NamiPaywallManagerBridgeModule(reactContext: ReactApplicationContext) :
     }
 
     @ReactMethod
+    fun registerDeeplinkActionHandler() {
+        NamiPaywallManager.registerDeepLinkHandler { activity , url ->
+            latestPaywallActivity = activity
+            reactApplicationContext
+                .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter::class.java)
+                .emit("PaywallDeeplinkAction", url)
+        }
+
+    }
+
+
+    @ReactMethod
     fun show() {
         // Do nothing on Android side
     }

--- a/examples/Basic/containers/CampaignScreen.tsx
+++ b/examples/Basic/containers/CampaignScreen.tsx
@@ -94,6 +94,12 @@ const CampaignScreen: FC<CampaignScreenProps> = ({ navigation }) => {
         NamiPaywallManager.dismiss();
       });
 
+    const subscriptionDeeplinkeRemover =
+      NamiPaywallManager.registerDeeplinkActionHandler((url) => {
+        console.log('deeplink action ', url);
+        NamiPaywallManager.dismiss();
+      });
+
     const subscriptionRemover =
         NamiCampaignManager.registerAvailableCampaignsHandler(
           (availableCampaigns) => {
@@ -108,6 +114,7 @@ const CampaignScreen: FC<CampaignScreenProps> = ({ navigation }) => {
       subscriptionRemover();
       subscriptionSignInRemover();
       subscriptionRestoreRemover();
+      subscriptionDeeplinkeRemover();
       // Clean up the launch subscription when the component unmounts
       // For safety reasons
       if (NamiCampaignManager.launchSubscription) {

--- a/ios/Nami.m
+++ b/ios/Nami.m
@@ -52,7 +52,7 @@ RCT_EXPORT_METHOD(configure: (NSDictionary *)configDict completion: (RCTResponse
         }
 
         // Start commands with header iformation for Nami to let them know this is a React client.
-        NSMutableArray *namiCommandStrings = [NSMutableArray arrayWithArray:@[@"extendedClientInfo:react-native:3.0.30"]];
+        NSMutableArray *namiCommandStrings = [NSMutableArray arrayWithArray:@[@"extendedClientInfo:react-native:3.0.31"]];
 
         // Add additional namiCommands app may have sent in.
         NSObject *appCommandStrings = configDict[@"namiCommands"];

--- a/ios/NamiCampaignManagerBridge.swift
+++ b/ios/NamiCampaignManagerBridge.swift
@@ -63,6 +63,8 @@ class RNNamiCampaignManager: RCTEventEmitter {
             actionString = "PURCHASE_SELECTED_SKU"
         case .purchase_success:
             actionString = "PURCHASE_SUCCESS"
+        case .purchase_pending:
+            actionString = "PURCHASE_PENDING"
         case .purchase_deferred:
             actionString = "PURCHASE_DEFERRED"
         case .purchase_failed:

--- a/ios/NamiPaywallManagerBridge.m
+++ b/ios/NamiPaywallManagerBridge.m
@@ -25,6 +25,8 @@ RCT_EXTERN_METHOD(registerSignInHandler)
 
 RCT_EXTERN_METHOD(registerRestoreHandler)
 
+RCT_EXTERN_METHOD(registerDeeplinkActionHandler)
+
 RCT_EXTERN_METHOD(dismiss:(BOOL)animated)
 
 RCT_EXTERN_METHOD(show)

--- a/ios/NamiPaywallManagerBridge.swift
+++ b/ios/NamiPaywallManagerBridge.swift
@@ -111,6 +111,13 @@ class RNNamiPaywallManager: RCTEventEmitter {
         }
     }
 
+    @objc(registerDeeplinkActionHandler)
+    func registerDeeplinkActionHandler() {
+        NamiPaywallManager.registerDeeplinkActionHandler { url in
+            RNNamiPaywallManager.shared?.sendEvent(withName: "PaywallDeeplinkAction", body: url)
+        }
+    }
+
     @objc(dismiss:)
     func dismiss(animated: Bool) {
         NamiPaywallManager.dismiss(animated: animated) {}

--- a/ios/NamiPaywallManagerBridge.swift
+++ b/ios/NamiPaywallManagerBridge.swift
@@ -19,7 +19,7 @@ class RNNamiPaywallManager: RCTEventEmitter {
     }
 
     override func supportedEvents() -> [String]! {
-        return ["RegisterBuySKU", "PaywallCloseRequested", "PaywallSignInRequested", "PaywallRestoreRequested"]
+        return ["RegisterBuySKU", "PaywallCloseRequested", "PaywallSignInRequested", "PaywallRestoreRequested", "PaywallDeeplinkAction"]
     }
 
     @objc(buySkuComplete:)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-nami-sdk",
-  "version": "3.0.30",
+  "version": "3.0.31",
   "description": "React Native Module for Nami - Easy subscriptions & in-app purchases, with powerful built-in paywalls and A/B testing.",
   "main": "index.ts",
   "types": "index.d.ts",

--- a/react-native-nami-sdk.podspec
+++ b/react-native-nami-sdk.podspec
@@ -20,7 +20,7 @@ Pod::Spec.new do |s|
   s.source_files = "ios/**/*.{h,m,swift}"
   s.requires_arc = true
 
-  s.dependency 'Nami', '3.1.6'
+  s.dependency 'Nami', '3.1.7'
   s.dependency 'React'
 
 end

--- a/src/NamiPaywallManager.d.ts
+++ b/src/NamiPaywallManager.d.ts
@@ -18,6 +18,9 @@ export const NamiPaywallManager: {
   registerRestoreHandler: (
     callback: () => void,
   ) => EmitterSubscription['remove'];
+  registerDeeplinkActionHandler: (
+    callback: (url: string) => void,
+  ) => EmitterSubscription['remove'];
   show: () => void;
   hide: () => void;
   buySkuCancel: () => void;

--- a/src/NamiPaywallManager.ts
+++ b/src/NamiPaywallManager.ts
@@ -15,6 +15,7 @@ export enum NamiPaywallManagerEvents {
   PaywallCloseRequested = 'PaywallCloseRequested',
   PaywallSignInRequested = 'PaywallSignInRequested',
   PaywallRestoreRequested = 'PaywallRestoreRequested',
+  PaywallDeeplinkAction = 'PaywallDeeplinkAction',
 }
 
 export enum ServicesEnum {
@@ -69,8 +70,7 @@ export const NamiPaywallManager: INamiPaywallManager = {
     RNNamiPaywallManager.buySkuCancel();
   },
   registerBuySkuHandler: (callback: (sku: NamiSKU) => void) => {
-    let subscription;
-    subscription = NamiPaywallManager.paywallEmitter.addListener(
+    let subscription = NamiPaywallManager.paywallEmitter.addListener(
       NamiPaywallManagerEvents.RegisterBuySKU,
       sku => {
         callback(sku);
@@ -84,8 +84,7 @@ export const NamiPaywallManager: INamiPaywallManager = {
     };
   },
   registerCloseHandler: (callback: (body: any) => void) => {
-    let subscription;
-    subscription = NamiPaywallManager.paywallEmitter.addListener(
+    let subscription = NamiPaywallManager.paywallEmitter.addListener(
       NamiPaywallManagerEvents.PaywallCloseRequested,
       body => {
         callback(body);
@@ -99,8 +98,7 @@ export const NamiPaywallManager: INamiPaywallManager = {
     };
   },
   registerSignInHandler(callback) {
-    let subscription;
-    subscription = NamiPaywallManager.paywallEmitter.addListener(
+    let subscription = NamiPaywallManager.paywallEmitter.addListener(
       NamiPaywallManagerEvents.PaywallSignInRequested,
       () => {
         callback();
@@ -115,14 +113,27 @@ export const NamiPaywallManager: INamiPaywallManager = {
     };
   },
   registerRestoreHandler(callback) {
-    let subscription;
-    subscription = NamiPaywallManager.paywallEmitter.addListener(
+    let subscription = NamiPaywallManager.paywallEmitter.addListener(
       NamiPaywallManagerEvents.PaywallRestoreRequested,
       () => {
         callback();
       },
     );
     RNNamiPaywallManager.registerRestoreHandler();
+    return () => {
+      if (subscription) {
+        subscription.remove();
+      }
+    };
+  },
+  registerDeeplinkActionHandler: (callback: (url: string) => void) => {
+    let subscription = NamiPaywallManager.paywallEmitter.addListener(
+      NamiPaywallManagerEvents.PaywallDeeplinkAction,
+      url => {
+        callback(url);
+      },
+    );
+    RNNamiPaywallManager.registerDeeplinkActionHandler();
     return () => {
       if (subscription) {
         subscription.remove();

--- a/src/NamiPaywallManager.ts
+++ b/src/NamiPaywallManager.ts
@@ -40,6 +40,9 @@ export interface INamiPaywallManager {
   registerRestoreHandler: (
     callback: () => void,
   ) => EmitterSubscription['remove'];
+  registerDeeplinkActionHandler: (
+    callback: (url: string) => void,
+  ) => EmitterSubscription['remove'];
   dismiss: (animated?: boolean) => void;
   show: () => void;
   hide: () => void;


### PR DESCRIPTION
# v3.0.31 (Sep 6, 2023)

## New Features
- Add `NamiPaywallManager.registerDeeplinkActionHandler` to receive callbacks and implement desired logic when a paywall button is tied to a deeplink action.

## Enhancements
- Emit `PURCHASE_PENDING` event during paywall launch lifecycle when the purchase process is initiated 

## Updated Native SDK Dependencies
- Android SDK v3.1.7- [Release Notes](https://github.com/namiml/nami-android/wiki/Nami-SDK-Stable-Releases#v317-seg-7-2023)
- Apple SDK v3.1.7- [Release Notes](https://github.com/namiml/nami-apple/wiki/Nami-SDK-Stable-Releases#v317-sep-6-2023)
