### PR TITLE
Resolve crash inside buySkuComplete

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -84,7 +84,7 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
 
     implementation 'com.github.jeziellago:compose-markdown:0.3.0'
-    compileOnly "com.namiml:sdk-amazon:3.1.7"
+    compileOnly "com.namiml:sdk-amazon:3.1.8"
 
     implementation 'com.facebook.react:react-native:+'  // From node_modules
     coreLibraryDesugaring "com.android.tools:desugar_jdk_libs:1.1.5"

--- a/android/src/main/java/com/nami/reactlibrary/NamiBridgeModule.kt
+++ b/android/src/main/java/com/nami/reactlibrary/NamiBridgeModule.kt
@@ -115,7 +115,7 @@ class NamiBridgeModule(reactContext: ReactApplicationContext) :
             } else {
                 Arguments.createArray()
             }
-        val settingsList = mutableListOf("extendedClientInfo:react-native:3.0.31")
+        val settingsList = mutableListOf("extendedClientInfo:react-native:3.0.32")
         namiCommandsReact?.toArrayList()?.filterIsInstance<String>()?.let { commandsFromReact ->
             settingsList.addAll(commandsFromReact)
         }

--- a/android/src/main/java/com/nami/reactlibrary/NamiPaywallManagerBridgeModule.kt
+++ b/android/src/main/java/com/nami/reactlibrary/NamiPaywallManagerBridgeModule.kt
@@ -25,7 +25,7 @@ class NamiPaywallManagerBridgeModule(reactContext: ReactApplicationContext) :
     fun buySkuComplete(dict: ReadableMap, storeType: String) {
         var product: ReadableMap? = null
         var productId: String? = null
-        var skuId: String? = null
+        var skuRefId: String? = null
         var typeString: String? = null
         var purchaseSourceString: String? = null
         var expiresDateInt: Int? = null
@@ -54,7 +54,7 @@ class NamiPaywallManagerBridgeModule(reactContext: ReactApplicationContext) :
             }
 
             if (product.hasKey("skuId")) {
-                skuId = product.getString("skuId")
+                skuRefId = product.getString("skuId")
             }
 
             if (product.hasKey("type")) {
@@ -75,21 +75,6 @@ class NamiPaywallManagerBridgeModule(reactContext: ReactApplicationContext) :
             purchaseDate = Date(purchaseDateInt * 1000L)
         }
 
-        skuType = when (typeString) {
-            "UNKNOWN" -> {
-                NamiSKUType.UNKNOWN
-            }
-            "SUBSCRIPTION" -> {
-                NamiSKUType.SUBSCRIPTION
-            }
-            "ONE_TIME_PURCHASE" -> {
-                NamiSKUType.ONE_TIME_PURCHASE
-            }
-            else -> {
-                NamiSKUType.UNKNOWN
-            }
-        }
-
         val purchaseSource = when (purchaseSourceString) {
             "CAMPAIGN" -> {
                 NamiPurchaseSource.CAMPAIGN
@@ -105,19 +90,10 @@ class NamiPaywallManagerBridgeModule(reactContext: ReactApplicationContext) :
             }
         }
 
-        if (productId != null && skuId != null && skuType != null) {
-            val namiSku = NamiSKU(
-                skuId = skuId,
-                productDetails = null,
-                amazonProduct = null,
-                id = productId,
-                type = skuType,
-                name = "",
-                featured = false,
-                rawDisplayText = null,
-                rawSubDisplayText = null,
-                entitlements = emptyList(),
-                variables = null,
+        if (productId != null && skuRefId != null) {
+            val namiSku = NamiSKU.create(
+                skuRefId = skuRefId,
+                skuId = productId,
             )
             var purchaseSuccess: NamiPurchaseSuccess? = null
 

--- a/examples/Basic/android/app/build.gradle
+++ b/examples/Basic/android/app/build.gradle
@@ -218,7 +218,7 @@ dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])
     implementation "com.facebook.react:react-native:+"  // From node_modules
     implementation 'com.github.jeziellago:compose-markdown:0.3.0'
-    implementation "com.namiml:sdk-android:3.1.5"
+    implementation "com.namiml:sdk-android:3.1.8"
 
     implementation project(':react-native-screens')
 

--- a/examples/Basic/containers/CustomerManagerScreen.tsx
+++ b/examples/Basic/containers/CustomerManagerScreen.tsx
@@ -53,7 +53,9 @@ const CustomerManagerScreen: FC<CustomerManagerScreenProps> = () => {
   };
 
   useEffect(() => {
-    handleAnonymousMode();
+    if (inAnonymousMode) {
+      handleAnonymousMode();
+    }
     // eslint-disable-next-line @typescript-eslint/no-empty-function
     return () => {};
     //Note: not needed in depts

--- a/examples/Basic/e2e/android/main.test.js
+++ b/examples/Basic/e2e/android/main.test.js
@@ -6,7 +6,7 @@ const data = {
 
 describe('Android: Configure Test', () => {
   beforeAll(async () => {
-    await device.launchApp();
+    await device.launchApp({ newInstance: true });
     await device.reloadReactNative();
   });
   afterAll(async () => {
@@ -201,7 +201,7 @@ describe('Android: Profile and Entitlements screen', () => {
 
     await waitFor(element(by.id('login_btn_text')))
       .toHaveText('Logout')
-      .withTimeout(5000);
+      .withTimeout(10000);
 
     await expect(element(by.id('user_id'))).toHaveText('Customer Id');
 
@@ -209,7 +209,7 @@ describe('Android: Profile and Entitlements screen', () => {
 
     await waitFor(element(by.id('login_btn_text')))
       .toHaveText('Login')
-      .withTimeout(5000);
+      .withTimeout(10000);
 
     await expect(element(by.id('user_id'))).toHaveText('Device Id');
   });

--- a/ios/Nami.m
+++ b/ios/Nami.m
@@ -52,7 +52,7 @@ RCT_EXPORT_METHOD(configure: (NSDictionary *)configDict completion: (RCTResponse
         }
 
         // Start commands with header iformation for Nami to let them know this is a React client.
-        NSMutableArray *namiCommandStrings = [NSMutableArray arrayWithArray:@[@"extendedClientInfo:react-native:3.0.31"]];
+        NSMutableArray *namiCommandStrings = [NSMutableArray arrayWithArray:@[@"extendedClientInfo:react-native:3.0.32"]];
 
         // Add additional namiCommands app may have sent in.
         NSObject *appCommandStrings = configDict[@"namiCommands"];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-nami-sdk",
-  "version": "3.0.31",
+  "version": "3.0.32",
   "description": "React Native Module for Nami - Easy subscriptions & in-app purchases, with powerful built-in paywalls and A/B testing.",
   "main": "index.ts",
   "types": "index.d.ts",


### PR DESCRIPTION
- Resolve a crash when we try to create a NamiSKU object inside of the android side of the bridge `buySkuComplete`. The NamiSKU data class constructor was not reliably available if the RN bridge was compiled with a different native SDK jar than what the app used in `implementation`. The issue is resolved by exposing a more directly public method for creating `NamiSKU`