### PR TITLE
3.1.11: improvements to configure and dependency updates

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -84,7 +84,7 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
 
     implementation 'com.github.jeziellago:compose-markdown:0.3.0'
-    compileOnly "com.namiml:sdk-amazon:3.1.10"
+    compileOnly "com.namiml:sdk-amazon:3.1.13-rc.01"
 
     implementation 'com.facebook.react:react-native:+'  // From node_modules
     coreLibraryDesugaring "com.android.tools:desugar_jdk_libs:1.1.5"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -84,7 +84,7 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
 
     implementation 'com.github.jeziellago:compose-markdown:0.3.0'
-    compileOnly "com.namiml:sdk-amazon:3.1.13-rc.01"
+    compileOnly "com.namiml:sdk-amazon:3.1.13"
 
     implementation 'com.facebook.react:react-native:+'  // From node_modules
     coreLibraryDesugaring "com.android.tools:desugar_jdk_libs:1.1.5"

--- a/android/src/main/java/com/nami/reactlibrary/NamiBridgeModule.kt
+++ b/android/src/main/java/com/nami/reactlibrary/NamiBridgeModule.kt
@@ -10,6 +10,7 @@ import com.facebook.react.bridge.ReactContextBaseJavaModule
 import com.facebook.react.bridge.ReactMethod
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
+import com.facebook.react.bridge.Promise
 import com.namiml.Nami
 import com.namiml.NamiConfiguration
 import com.namiml.NamiLanguageCode
@@ -44,15 +45,7 @@ class NamiBridgeModule(reactContext: ReactApplicationContext) :
         }
 
         val appContext: Context = reactApplicationContext.applicationContext
-        Log.i(LOG_TAG, "Configure called with appID $appPlatformID")
-        Log.i(LOG_TAG, "Configure called with context $reactApplicationContext")
-        Log.i(LOG_TAG, "Nami Configure called with context.applicationContext $appContext")
-
-        val isApplication: Boolean = (appContext is Application)
-        Log.i(LOG_TAG, "Configure called with (context as Application) $isApplication.")
-        Log.i(LOG_TAG, "End Application check ")
-
-        // Application fred = (reactContext as Application);
+        Log.d(LOG_TAG, "NAMI: RN Bridge - Configure called with appPlatformID $appPlatformID")
 
         val builder: NamiConfiguration.Builder =
             NamiConfiguration.Builder(appContext, appPlatformID)
@@ -78,15 +71,15 @@ class NamiBridgeModule(reactContext: ReactApplicationContext) :
                 builder.logLevel(NamiLogLevel.DEBUG)
             }
         }
-        Log.i(LOG_TAG, "Nami Configuration log level passed in is $logLevelString")
+        Log.d(LOG_TAG, "NAMI: RN Bridge - configuration log level is $logLevelString")
 
         val developmentMode = if (configDict.hasKey(CONFIG_MAP_DEVELOPMENT_MODE_KEY)) {
             configDict.getBoolean(CONFIG_MAP_DEVELOPMENT_MODE_KEY)
         } else {
             false
         }
-        Log.i(LOG_TAG, "Nami Configuration developmentMode is $developmentMode")
         if (developmentMode) {
+                    Log.d(LOG_TAG, "NAMI: RN Bridge - development mode is $developmentMode")
             builder.developmentMode = true
         }
 
@@ -115,11 +108,11 @@ class NamiBridgeModule(reactContext: ReactApplicationContext) :
             } else {
                 Arguments.createArray()
             }
-        val settingsList = mutableListOf("extendedClientInfo:react-native:3.1.10")
+        val settingsList = mutableListOf("extendedClientInfo:react-native:3.1.11")
         namiCommandsReact?.toArrayList()?.filterIsInstance<String>()?.let { commandsFromReact ->
             settingsList.addAll(commandsFromReact)
         }
-        Log.i(LOG_TAG, "Nami Configuration command settings are $settingsList")
+        Log.d(LOG_TAG, "Nami Configuration command settings are $settingsList")
         builder.settingsList = settingsList
 
         val initialConfig = if (configDict.hasKey(CONFIG_MAP_INITIAL_CONFIG_KEY)) {
@@ -128,7 +121,7 @@ class NamiBridgeModule(reactContext: ReactApplicationContext) :
             null
         }
         initialConfig?.let { initialConfigString ->
-            Log.i(
+            Log.d(
                 LOG_TAG,
                 "Nami Configuration initialConfig found.",
             )
@@ -136,14 +129,16 @@ class NamiBridgeModule(reactContext: ReactApplicationContext) :
         }
 
         val builtConfig: NamiConfiguration = builder.build()
-        Log.i(LOG_TAG, "Nami Configuration object is $builtConfig")
+        Log.d(LOG_TAG, "Nami Configuration object is $builtConfig")
 
         reactApplicationContext.runOnUiQueueThread {
+
             // Configure must be called on main thread
-            Nami.configure(builtConfig)
-            val resultMap = Arguments.createMap()
-            resultMap.putBoolean("success", true)
-            completion.invoke(resultMap)
+            Nami.configure(builtConfig) { result ->
+                val resultMap = Arguments.createMap()
+                resultMap.putBoolean("success", result)
+                completion.invoke(resultMap)
+            }
         }
     }
 }

--- a/android/src/main/java/com/nami/reactlibrary/NamiBridgePackage.java
+++ b/android/src/main/java/com/nami/reactlibrary/NamiBridgePackage.java
@@ -24,6 +24,7 @@ public class NamiBridgePackage implements ReactPackage {
         moduleList.add(new NamiPurchaseManagerBridgeModule(reactContext));
         moduleList.add(new NamiEntitlementManagerBridgeModule(reactContext));
         moduleList.add(new NamiMLManagerBridgeModule(reactContext));
+        moduleList.add(new NamiManagerBridgeModule(reactContext));
         moduleList.add(new NamiCustomerManagerBridgeModule(reactContext));
         moduleList.add(new NamiCampaignManagerBridgeModule(reactContext));
 

--- a/android/src/main/java/com/nami/reactlibrary/NamiCampaignManagerBridge.kt
+++ b/android/src/main/java/com/nami/reactlibrary/NamiCampaignManagerBridge.kt
@@ -156,6 +156,7 @@ class NamiCampaignManagerBridgeModule(reactContext: ReactApplicationContext) :
             putString(EXTERNAL_SEGMENT_ID, paywallEvent.externalSegmentId ?: "")
             putString(DEEP_LINK_URL, paywallEvent.deeplinkUrl ?: "")
         }
+        Log.d(LOG_TAG, "Paywall event being emitted - $resultMap")
 
         emitEvent(_RESULT_CAMPAIGN, resultMap)
     }

--- a/android/src/main/java/com/nami/reactlibrary/NamiCampaignManagerBridge.kt
+++ b/android/src/main/java/com/nami/reactlibrary/NamiCampaignManagerBridge.kt
@@ -156,8 +156,6 @@ class NamiCampaignManagerBridgeModule(reactContext: ReactApplicationContext) :
             putString(EXTERNAL_SEGMENT_ID, paywallEvent.externalSegmentId ?: "")
             putString(DEEP_LINK_URL, paywallEvent.deeplinkUrl ?: "")
         }
-        Log.d(LOG_TAG, "Paywall event being emitted - $resultMap")
-
         emitEvent(_RESULT_CAMPAIGN, resultMap)
     }
 

--- a/android/src/main/java/com/nami/reactlibrary/NamiManagerBridge.kt
+++ b/android/src/main/java/com/nami/reactlibrary/NamiManagerBridge.kt
@@ -1,0 +1,28 @@
+package com.nami.reactlibrary
+
+import android.util.Log
+import com.facebook.react.bridge.*
+import com.facebook.react.modules.core.DeviceEventManagerModule
+import com.namiml.Nami
+
+class NamiManagerBridgeModule(reactContext: ReactApplicationContext) :
+    ReactContextBaseJavaModule(reactContext) {
+
+    override fun getName(): String {
+        return "RNNamiManager"
+    }
+
+    @ReactMethod
+    fun sdkConfigured(promise: Promise) {
+        val sdkConfigured = Nami.isInitialized()
+        promise.resolve(sdkConfigured)
+    }
+
+    @ReactMethod
+    fun addListener(eventName: String?) {
+    }
+
+    @ReactMethod
+    fun removeListeners(count: Int?) {
+    }
+}

--- a/android/src/main/java/com/nami/reactlibrary/NamiPaywallManagerBridgeModule.kt
+++ b/android/src/main/java/com/nami/reactlibrary/NamiPaywallManagerBridgeModule.kt
@@ -240,6 +240,12 @@ class NamiPaywallManagerBridgeModule(reactContext: ReactApplicationContext) :
     }
 
     @ReactMethod
+    fun isPaywallOpen(promise: Promise) {
+        val paywallOpen = NamiPaywallManager.isPaywallOpen()
+        promise.resolve(paywallOpen)
+    }
+
+    @ReactMethod
     fun buySkuCancel() {
         NamiPaywallManager.buySkuCancel()
     }

--- a/examples/Basic/App.tsx
+++ b/examples/Basic/App.tsx
@@ -3,7 +3,7 @@ import { Linking, Platform } from 'react-native';
 import { NavigationContainer } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
-import { NamiCustomerManager, NamiPaywallManager } from 'react-native-nami-sdk';
+import { NamiPaywallManager } from 'react-native-nami-sdk';
 
 import CampaignScreen from './containers/CampaignScreen';
 import ProfileScreen from './containers/ProfileScreen';

--- a/examples/Basic/App.tsx
+++ b/examples/Basic/App.tsx
@@ -93,7 +93,6 @@ const App = () => {
       },
     );
 
-    NamiCustomerManager.setCustomerDataPlatformId('2135');
     return () => {
       subscriptionRemover();
     };

--- a/examples/Basic/android/app/build.gradle
+++ b/examples/Basic/android/app/build.gradle
@@ -126,6 +126,10 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
+    lintOptions {
+        checkReleaseBuilds false
+    }
+
     defaultConfig {
         applicationId "com.namiml.stg.testreactnative"
         minSdkVersion 26
@@ -177,6 +181,7 @@ android {
             storePassword 'android'
             keyAlias 'androidreleasekey'
             keyPassword 'android'
+            v2SigningEnabled true
         }
     }
     buildTypes {
@@ -186,8 +191,9 @@ android {
         release {
             // Caution! In production, you need to generate your own keystore file.
             // see https://facebook.github.io/react-native/docs/signed-apk-android.
-            signingConfig null
-            minifyEnabled enableProguardInReleaseBuilds
+            signingConfig signingConfigs.release
+	        minifyEnabled true
+            shrinkResources = true
             proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
             proguardFile "${rootProject.projectDir}/../node_modules/detox/android/detox/proguard-rules-app.pro"
         }
@@ -218,7 +224,7 @@ dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])
     implementation "com.facebook.react:react-native:+"  // From node_modules
     implementation 'com.github.jeziellago:compose-markdown:0.3.0'
-    implementation "com.namiml:sdk-android:3.1.10"
+    implementation "com.namiml:sdk-android:3.1.13-rc.01"
 
     implementation project(':react-native-screens')
 

--- a/examples/Basic/android/app/build.gradle
+++ b/examples/Basic/android/app/build.gradle
@@ -177,10 +177,10 @@ android {
             keyPassword 'android'
         }
         release {
-            storeFile file('release.keystore')
-            storePassword 'android'
-            keyAlias 'androidreleasekey'
-            keyPassword 'android'
+            storeFile file('/Users/dannami/Nami/SigningKeys/GooglePlay/release.keystore')
+            storePassword 'kyFYiLg7QVe78QaEg'
+            keyAlias 'namirelease'
+            keyPassword 'kyFYiLg7QVe78QaEg'
             v2SigningEnabled true
         }
     }
@@ -224,7 +224,7 @@ dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])
     implementation "com.facebook.react:react-native:+"  // From node_modules
     implementation 'com.github.jeziellago:compose-markdown:0.3.0'
-    implementation "com.namiml:sdk-android:3.1.13-rc.01"
+    implementation "com.namiml:sdk-android:3.1.13"
 
     implementation project(':react-native-screens')
 

--- a/examples/Basic/android/app/build.gradle
+++ b/examples/Basic/android/app/build.gradle
@@ -191,8 +191,8 @@ android {
         release {
             // Caution! In production, you need to generate your own keystore file.
             // see https://facebook.github.io/react-native/docs/signed-apk-android.
-            signingConfig signingConfigs.release
-	        minifyEnabled true
+            signingConfig null
+	    minifyEnabled true
             shrinkResources = true
             proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
             proguardFile "${rootProject.projectDir}/../node_modules/detox/android/detox/proguard-rules-app.pro"

--- a/examples/Basic/android/app/build.gradle
+++ b/examples/Basic/android/app/build.gradle
@@ -177,10 +177,10 @@ android {
             keyPassword 'android'
         }
         release {
-            storeFile file('/Users/dannami/Nami/SigningKeys/GooglePlay/release.keystore')
-            storePassword 'kyFYiLg7QVe78QaEg'
-            keyAlias 'namirelease'
-            keyPassword 'kyFYiLg7QVe78QaEg'
+            storeFile file('release.keystore')
+            storePassword 'android'
+            keyAlias 'androidreleasekey'
+            keyPassword 'android'
             v2SigningEnabled true
         }
     }

--- a/examples/Basic/config/getInitialConfig.ts
+++ b/examples/Basic/config/getInitialConfig.ts
@@ -17,7 +17,7 @@ export const getInitialConfig = () => {
       );
     case 'ios':
       return JSON.stringify(
-        flavor !== 'production'
+        flavor === 'production'
           ? initAppleProductionConfig
           : initAppleStageConfig,
       );

--- a/examples/Basic/config/index.ts
+++ b/examples/Basic/config/index.ts
@@ -7,8 +7,8 @@ export function getConfigObject() {
   switch (flavor) {
     case 'staging':
       return {
-        'appPlatformID-apple': '4a2f6dbf-e684-4d65-a4df-0488771c577d',
-        'appPlatformID-android': 'b7232eba-ff1d-4b7f-b8d0-55593b66c1d5',
+        'appPlatformID-apple': 'APPLE_STG_APP_PLATFORM_ID',
+        'appPlatformID-android': 'ANDROID_STG_APP_PLATFORM_ID',
         logLevel: 'DEBUG',
         namiCommands: ['useStagingAPI', 'useNamiWindow'],
         initialConfig: getInitialConfig(),

--- a/examples/Basic/config/index.ts
+++ b/examples/Basic/config/index.ts
@@ -7,8 +7,8 @@ export function getConfigObject() {
   switch (flavor) {
     case 'staging':
       return {
-        'appPlatformID-apple': 'APPLE_STG_APP_PLATFORM_ID',
-        'appPlatformID-android': 'ANDROID_STG_APP_PLATFORM_ID',
+        'appPlatformID-apple': '4a2f6dbf-e684-4d65-a4df-0488771c577d',
+        'appPlatformID-android': 'b7232eba-ff1d-4b7f-b8d0-55593b66c1d5',
         logLevel: 'DEBUG',
         namiCommands: ['useStagingAPI', 'useNamiWindow'],
         initialConfig: getInitialConfig(),

--- a/examples/Basic/containers/CampaignScreen.tsx
+++ b/examples/Basic/containers/CampaignScreen.tsx
@@ -59,7 +59,7 @@ const CampaignScreen: FC<CampaignScreenProps> = ({ navigation }) => {
   const checkIfPaywallOpen = async () => {
     const isOpen = await NamiPaywallManager.isPaywallOpen();
     console.log('NamiSDK: paywall open? ', isOpen);
-};
+  };
 
   const showPaywallIfHidden = async () => {
     try {

--- a/examples/Basic/containers/CampaignScreen.tsx
+++ b/examples/Basic/containers/CampaignScreen.tsx
@@ -56,6 +56,11 @@ const CampaignScreen: FC<CampaignScreenProps> = ({ navigation }) => {
     'INITIAL',
   );
 
+  const checkIfPaywallOpen = async () => {
+    const isOpen = await NamiPaywallManager.isPaywallOpen();
+    console.log('NamiSDK: paywall open? ', isOpen);
+};
+
   const showPaywallIfHidden = async () => {
     try {
       const isHidden = await NamiPaywallManager.isHidden()
@@ -129,6 +134,8 @@ const CampaignScreen: FC<CampaignScreenProps> = ({ navigation }) => {
   }, []);
 
   const triggerLaunch = (label?: any, url?: any) => {
+    checkIfPaywallOpen();
+
     return NamiCampaignManager.launch(
       label,
       url,
@@ -136,6 +143,9 @@ const CampaignScreen: FC<CampaignScreenProps> = ({ navigation }) => {
       (successAction, error) => {
         console.log('successAction', successAction);
         console.log('error', error);
+
+        checkIfPaywallOpen();
+
       },
       (
         action,

--- a/examples/Basic/containers/ProfileScreen.tsx
+++ b/examples/Basic/containers/ProfileScreen.tsx
@@ -154,7 +154,7 @@ const ProfileScreen: FC<ProfileScreenProps> = ({ navigation }) => {
         },
       );
 
-      NamiCustomerManager.setCustomerDataPlatformId('4444');
+    NamiCustomerManager.setCustomerDataPlatformId('4444');
 
     return () => {
       subscriptionJourneyStateRemover();

--- a/examples/Basic/containers/ProfileScreen.tsx
+++ b/examples/Basic/containers/ProfileScreen.tsx
@@ -153,6 +153,9 @@ const ProfileScreen: FC<ProfileScreenProps> = ({ navigation }) => {
           }
         },
       );
+
+      NamiCustomerManager.setCustomerDataPlatformId('4444');
+
     return () => {
       subscriptionJourneyStateRemover();
       subscriptionAccountStateRemover();

--- a/examples/Basic/index.js
+++ b/examples/Basic/index.js
@@ -4,7 +4,7 @@
 import React, { useEffect, useState } from 'react';
 import { View } from 'react-native';
 import { AppRegistry } from 'react-native';
-import { Nami } from 'react-native-nami-sdk';
+import { Nami, NamiManager } from 'react-native-nami-sdk';
 import App from './App';
 import { name as appName } from './app.json';
 import { getConfigObject } from './config';
@@ -12,14 +12,29 @@ import { getConfigObject } from './config';
 const configDict = getConfigObject();
 console.log('configDict', configDict);
 
+
 const Root = () => {
   const [isConfigurationComplete, setIsConfigurationComplete] = useState();
+
+  const checkSdkConfigured = async () => {
+      const configured = await NamiManager.sdkConfigured();
+      console.log('NamiSDK: configured', configured);
+  };
+
   useEffect(() => {
+
+    checkSdkConfigured();
+
     Nami.configure(configDict, (resultObject) => {
-      setIsConfigurationComplete(resultObject.success);
+      setIsConfigurationComplete(true);
+      checkSdkConfigured();
+
     });
+
     // eslint-disable-next-line @typescript-eslint/no-empty-function
     return () => {};
+
+
   }, []);
 
   return isConfigurationComplete ? <App /> : <View />;

--- a/examples/Basic/index.js
+++ b/examples/Basic/index.js
@@ -17,8 +17,8 @@ const Root = () => {
   const [isConfigurationComplete, setIsConfigurationComplete] = useState();
 
   const checkSdkConfigured = async () => {
-      const configured = await NamiManager.sdkConfigured();
-      console.log('NamiSDK: configured', configured);
+    const configured = await NamiManager.sdkConfigured();
+    console.log('NamiSDK: configured', configured);
   };
 
   useEffect(() => {

--- a/examples/TestNamiTV/android/app/build.gradle
+++ b/examples/TestNamiTV/android/app/build.gradle
@@ -227,8 +227,8 @@ dependencies {
     implementation "com.facebook.react:react-native:+"  // From node_modules
     implementation 'com.github.jeziellago:compose-markdown:0.3.0'
 
-    amazonImplementation "com.namiml:sdk-amazon:3.1.10"
-    playImplementation "com.namiml:sdk-android:3.1.10"
+    amazonImplementation "com.namiml:sdk-amazon::3.1.13-rc.01"
+    playImplementation "com.namiml:sdk-android::3.1.13-rc.01"
 
     if (enableHermes) {
         def hermesPath = "../../node_modules/hermes-engine/android/";

--- a/examples/TestNamiTV/android/app/build.gradle
+++ b/examples/TestNamiTV/android/app/build.gradle
@@ -227,8 +227,8 @@ dependencies {
     implementation "com.facebook.react:react-native:+"  // From node_modules
     implementation 'com.github.jeziellago:compose-markdown:0.3.0'
 
-    amazonImplementation "com.namiml:sdk-amazon::3.1.13-rc.01"
-    playImplementation "com.namiml:sdk-android::3.1.13-rc.01"
+    amazonImplementation "com.namiml:sdk-amazon::3.1.13"
+    playImplementation "com.namiml:sdk-android::3.1.13"
 
     if (enableHermes) {
         def hermesPath = "../../node_modules/hermes-engine/android/";

--- a/index.d.ts
+++ b/index.d.ts
@@ -3,6 +3,7 @@ export { NamiMLManager } from './src/NamiMLManager';
 export { NamiCampaignManager } from './src/NamiCampaignManager';
 export { NamiCustomerManager } from './src/NamiCustomerManager';
 export { NamiEntitlementManager } from './src/NamiEntitlementManager';
+export { NamiManager } from './src/NamiManager';
 export { NamiPurchaseManager } from './src/NamiPurchaseManager';
 export { NamiPaywallManager } from './src/NamiPaywallManager';
 export * from './src/types';

--- a/index.ts
+++ b/index.ts
@@ -3,6 +3,7 @@ export { NamiMLManager } from './src/NamiMLManager';
 export { NamiCampaignManager } from './src/NamiCampaignManager';
 export { NamiCustomerManager } from './src/NamiCustomerManager';
 export { NamiEntitlementManager } from './src/NamiEntitlementManager';
+export { NamiManager } from './src/NamiManager';
 export { NamiPurchaseManager } from './src/NamiPurchaseManager';
 export { NamiPaywallManager } from './src/NamiPaywallManager';
 export * from './src/types';

--- a/ios/NamiManager.m
+++ b/ios/NamiManager.m
@@ -1,0 +1,18 @@
+//
+//  NamiManager.m
+//  RNNami
+//
+//  Copyright © 2020-2023 Nami ML Inc. All rights reserved.
+//
+
+#import <React/RCTBridgeModule.h>
+
+@interface RCT_EXTERN_MODULE(RNNamiManager, NSObject)
+
+RCT_EXTERN_METHOD(sdkConfigured:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
+
++ (BOOL)requiresMainQueueSetup {
+  return YES;
+}
+
+@end

--- a/ios/NamiManager.swift
+++ b/ios/NamiManager.swift
@@ -1,0 +1,30 @@
+//
+//  NamiManager.swift
+//  RNNami
+//
+//  Copyright © 2023 Nami ML INc.. All rights reserved.
+//
+
+import Foundation
+import NamiApple
+import React
+
+@objc(RNNamiManager)
+class RNNamiManager: RCTEventEmitter {
+    public static var shared: RNNamiManager?
+
+    override init() {
+        super.init()
+        RNNamiManager.shared = self
+    }
+
+    override func supportedEvents() -> [String]! {
+        return []
+    }
+
+    @objc(sdkConfigured:rejecter:)
+    func sdkConfigured(resolve: @escaping RCTPromiseResolveBlock, reject _: @escaping RCTPromiseRejectBlock) {
+        let sdkConfigured = Nami.sdkConfigured()
+        resolve(sdkConfigured)
+    }
+}

--- a/ios/NamiPaywallManagerBridge.m
+++ b/ios/NamiPaywallManagerBridge.m
@@ -35,6 +35,8 @@ RCT_EXTERN_METHOD(hide)
 
 RCT_EXTERN_METHOD(isHidden:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
 
+RCT_EXTERN_METHOD(isPaywallOpen:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
+
 RCT_EXTERN_METHOD(buySkuCancel)
 
 + (BOOL)requiresMainQueueSetup {

--- a/ios/NamiPaywallManagerBridge.swift
+++ b/ios/NamiPaywallManagerBridge.swift
@@ -151,4 +151,12 @@ class RNNamiPaywallManager: RCTEventEmitter {
             resolve(isHidden)
         }
     }
+
+    @objc(isPaywallOpen:rejecter:)
+    func isPaywallOpen(resolve: @escaping RCTPromiseResolveBlock, reject _: @escaping RCTPromiseRejectBlock) {
+        DispatchQueue.main.async {
+            let isPaywallOpen = NamiPaywallManager.isPaywallOpen()
+            resolve(isPaywallOpen)
+        }
+    }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-nami-sdk",
-  "version": "3.1.10",
+  "version": "3.1.11",
   "description": "React Native Module for Nami - Easy subscriptions & in-app purchases, with powerful built-in paywalls and A/B testing.",
   "main": "index.ts",
   "types": "index.d.ts",

--- a/react-native-nami-sdk.podspec
+++ b/react-native-nami-sdk.podspec
@@ -20,7 +20,7 @@ Pod::Spec.new do |s|
   s.source_files = "ios/**/*.{h,m,swift}"
   s.requires_arc = true
 
-  s.dependency 'Nami', '3.1.10'
+  s.dependency 'Nami', '3.1.12'
   s.dependency 'React'
 
 end

--- a/src/Nami.ts
+++ b/src/Nami.ts
@@ -1,7 +1,7 @@
 import { NativeModules } from 'react-native';
 import { NamiConfiguration } from './types';
 
-export const { NamiBridge } = NativeModules;
+export const { NamiBridge, NamiManager } = NativeModules;
 
 export interface INami {
   configure: (

--- a/src/NamiCustomerManager.d.ts
+++ b/src/NamiCustomerManager.d.ts
@@ -1,4 +1,5 @@
 import { EmitterSubscription } from 'react-native';
+import { AccountStateAction } from './types';
 
 export const NamiCustomerManager: {
   setCustomerAttribute: (key: string, value: string) => void;
@@ -36,17 +37,3 @@ export type CustomerJourneyState = {
   inPause: boolean;
   inAccountHold: boolean;
 };
-
-export type AccountStateAction =
-  | 'login'
-  | 'logout'
-  | 'advertising_id_set'
-  | 'vendor_id_set'
-  | 'customer_data_platform_id_set'
-  | 'nami_device_id_set'
-  | 'advertising_id_cleared'
-  | 'vendor_id_cleared'
-  | 'customer_data_platform_id_cleared'
-  | 'nami_device_id_cleared'
-  | 'anonymous_mode_on'
-  | 'anonymous_mode_off';

--- a/src/NamiManager.d.ts
+++ b/src/NamiManager.d.ts
@@ -1,0 +1,3 @@
+export const NamiManager: {
+  sdkConfigured: () => Promise<boolean>;
+};

--- a/src/NamiManager.ts
+++ b/src/NamiManager.ts
@@ -1,0 +1,14 @@
+import { NativeModules } from 'react-native';
+
+export const { RNNamiManager } = NativeModules;
+
+export interface INamiManager {
+  sdkConfigured: () => Promise<boolean>;
+}
+
+export const NamiManager: INamiManager = {
+  ...RNNamiManager,
+  sdkConfigured: () => {
+    return RNNamiManager.sdkConfigured();
+  },
+};

--- a/src/NamiPaywallManager.d.ts
+++ b/src/NamiPaywallManager.d.ts
@@ -25,6 +25,7 @@ export const NamiPaywallManager: {
   hide: () => void;
   buySkuCancel: () => void;
   isHidden: () => Promise<boolean>;
+  isPaywallOpen: () => Promise<boolean>;
 };
 
 export type NamiPurchaseSuccessApple = {

--- a/src/NamiPaywallManager.ts
+++ b/src/NamiPaywallManager.ts
@@ -48,6 +48,7 @@ export interface INamiPaywallManager {
   show: () => void;
   hide: () => void;
   isHidden: () => Promise<boolean>;
+  isPaywallOpen: () => Promise<boolean>;
 }
 
 const { NamiPaywallManagerBridge, RNNamiPaywallManager } = NativeModules;
@@ -155,5 +156,8 @@ export const NamiPaywallManager: INamiPaywallManager = {
   },
   isHidden: () => {
     return RNNamiPaywallManager.isHidden();
+  },
+  isPaywallOpen: () => {
+    return RNNamiPaywallManager.isPaywallOpen();
   },
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -193,7 +193,6 @@ export type PaywallLaunchContext = {
   };
 };
 
-// NamiCustomerManager
 export type CustomerJourneyState = {
   formerSubscriber: boolean;
   inGracePeriod: boolean;
@@ -204,7 +203,19 @@ export type CustomerJourneyState = {
   inAccountHold: boolean;
 };
 
-export type AccountStateAction = 'login' | 'logout';
+export type AccountStateAction =
+  | 'login'
+  | 'logout'
+  | 'advertising_id_set'
+  | 'vendor_id_set'
+  | 'customer_data_platform_id_set'
+  | 'nami_device_id_set'
+  | 'advertising_id_cleared'
+  | 'vendor_id_cleared'
+  | 'customer_data_platform_id_cleared'
+  | 'nami_device_id_cleared'
+  | 'anonymous_mode_on'
+  | 'anonymous_mode_off';
 
 // NamiEntitlementManager
 export type NamiEntitlement = {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,7 @@
     // "sourceMap": true,                     /* Generates corresponding '.map' file. */
     // "outFile": "./",                       /* Concatenate and emit output to single file. */
      "outDir": "dist",                        /* Redirect output structure to the directory. */
-     "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
+     "rootDir": "src",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
     // "removeComments": true,                /* Do not emit comments to output. */
     "noEmit": true,                           /* Do not emit outputs. */
     // "incremental": true,                   /* Enable incremental compilation */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,7 @@
     // "sourceMap": true,                     /* Generates corresponding '.map' file. */
     // "outFile": "./",                       /* Concatenate and emit output to single file. */
      "outDir": "dist",                        /* Redirect output structure to the directory. */
-     "rootDir": "src",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
+     "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
     // "removeComments": true,                /* Do not emit comments to output. */
     "noEmit": true,                           /* Do not emit outputs. */
     // "incremental": true,                   /* Enable incremental compilation */


### PR DESCRIPTION
This is a stability focused release containing a number of improvements and safe guards to avoid crashes or incorrect state.

## Notable Fixes
- Apple: Don't allow the SDK to be configured multiple times within the same app initialization
- Android: Guard against potential crashes if certain methods were invoked before the SDK was configured
- Native SDK configure callback are now using in the RN `Nami.configure`
- 
## Enhancements
- Add `NamiPaywallManager.isPaywallOpen` to check if a paywall is already being presented to the user
- Add `NamiManager.sdkConfigured` to check if the sdk is already configured

## Updated Native SDK Dependencies
- Apple SDK v3.1.12- [Release Notes](https://github.com/namiml/nami-apple/wiki/Nami-SDK-Stable-Releases#v3112-sep-26-2023)
- Android SDK v3.1.13- [Release Notes](https://github.com/namiml/nami-android/wiki/Nami-SDK-Stable-Releases#v3113-sep-26-2023)
