### PR TITLE
Bump Apple dependency 

### DIFF
--- a/android/src/main/java/com/nami/reactlibrary/NamiBridgeModule.kt
+++ b/android/src/main/java/com/nami/reactlibrary/NamiBridgeModule.kt
@@ -108,7 +108,7 @@ class NamiBridgeModule(reactContext: ReactApplicationContext) :
             } else {
                 Arguments.createArray()
             }
-        val settingsList = mutableListOf("extendedClientInfo:react-native:3.1.11")
+        val settingsList = mutableListOf("extendedClientInfo:react-native:3.1.12")
         namiCommandsReact?.toArrayList()?.filterIsInstance<String>()?.let { commandsFromReact ->
             settingsList.addAll(commandsFromReact)
         }

--- a/ios/Nami.m
+++ b/ios/Nami.m
@@ -50,7 +50,7 @@ RCT_EXPORT_METHOD(configure: (NSDictionary *)configDict completion: (RCTResponse
         }
 
         // Start commands with header iformation for Nami to let them know this is a React client.
-        NSMutableArray *namiCommandStrings = [NSMutableArray arrayWithArray:@[@"extendedClientInfo:react-native:3.1.11"]];
+        NSMutableArray *namiCommandStrings = [NSMutableArray arrayWithArray:@[@"extendedClientInfo:react-native:3.1.12"]];
 
         // Add additional namiCommands app may have sent in.
         NSObject *appCommandStrings = configDict[@"namiCommands"];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-nami-sdk",
-  "version": "3.1.11",
+  "version": "3.1.12",
   "description": "React Native Module for Nami - Easy subscriptions & in-app purchases, with powerful built-in paywalls and A/B testing.",
   "main": "index.ts",
   "types": "index.d.ts",

--- a/react-native-nami-sdk.podspec
+++ b/react-native-nami-sdk.podspec
@@ -20,7 +20,7 @@ Pod::Spec.new do |s|
   s.source_files = "ios/**/*.{h,m,swift}"
   s.requires_arc = true
 
-  s.dependency 'Nami', '3.1.12'
+  s.dependency 'Nami', '3.1.13'
   s.dependency 'React'
 
 end


### PR DESCRIPTION
# ChangeLog 

Apple dependency bump resolves an edge case where a background listener could start listening, and making API requests, even if the SDK isn't in a fully configured state, but has some fully configured artifacts in cache from prior runs of the app install.

## Updated Native SDK Dependencies
- Apple SDK v3.1.13- [Release Notes](https://github.com/namiml/nami-apple/wiki/Nami-SDK-Stable-Releases#v3113-sep-28-2023)
