### PR TITLE
3.1.17

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -84,7 +84,7 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
 
     implementation 'com.github.jeziellago:compose-markdown:0.3.0'
-    compileOnly "com.namiml:sdk-amazon:3.1.16"
+    compileOnly "com.namiml:sdk-amazon:3.1.17"
 
     implementation 'com.facebook.react:react-native:+'  // From node_modules
     coreLibraryDesugaring "com.android.tools:desugar_jdk_libs:1.1.5"

--- a/android/src/main/java/com/nami/reactlibrary/NamiBridgeModule.kt
+++ b/android/src/main/java/com/nami/reactlibrary/NamiBridgeModule.kt
@@ -1,6 +1,5 @@
 package com.nami.reactlibrary
 
-import android.app.Application
 import android.content.Context
 import android.util.Log
 import com.facebook.react.bridge.Arguments
@@ -10,7 +9,6 @@ import com.facebook.react.bridge.ReactContextBaseJavaModule
 import com.facebook.react.bridge.ReactMethod
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
-import com.facebook.react.bridge.Promise
 import com.namiml.Nami
 import com.namiml.NamiConfiguration
 import com.namiml.NamiLanguageCode
@@ -79,7 +77,7 @@ class NamiBridgeModule(reactContext: ReactApplicationContext) :
             false
         }
         if (developmentMode) {
-                    Log.d(LOG_TAG, "NAMI: RN Bridge - development mode is $developmentMode")
+            Log.d(LOG_TAG, "NAMI: RN Bridge - development mode is $developmentMode")
             builder.developmentMode = true
         }
 
@@ -108,7 +106,7 @@ class NamiBridgeModule(reactContext: ReactApplicationContext) :
             } else {
                 Arguments.createArray()
             }
-        val settingsList = mutableListOf("extendedClientInfo:react-native:3.1.14")
+        val settingsList = mutableListOf("extendedClientInfo:react-native:3.1.17")
         namiCommandsReact?.toArrayList()?.filterIsInstance<String>()?.let { commandsFromReact ->
             settingsList.addAll(commandsFromReact)
         }
@@ -132,7 +130,6 @@ class NamiBridgeModule(reactContext: ReactApplicationContext) :
         Log.d(LOG_TAG, "Nami Configuration object is $builtConfig")
 
         reactApplicationContext.runOnUiQueueThread {
-
             // Configure must be called on main thread
             Nami.configure(builtConfig) { result ->
                 val resultMap = Arguments.createMap()

--- a/android/src/main/java/com/nami/reactlibrary/NamiCampaignManagerBridge.kt
+++ b/android/src/main/java/com/nami/reactlibrary/NamiCampaignManagerBridge.kt
@@ -10,8 +10,8 @@ import com.namiml.billing.NamiPurchase
 import com.namiml.campaign.LaunchCampaignResult
 import com.namiml.campaign.NamiCampaign
 import com.namiml.campaign.NamiCampaignManager
-import com.namiml.paywall.model.PaywallLaunchContext
 import com.namiml.paywall.model.NamiPaywallEvent
+import com.namiml.paywall.model.PaywallLaunchContext
 
 class NamiCampaignManagerBridgeModule(reactContext: ReactApplicationContext) :
     ReactContextBaseJavaModule(reactContext), ActivityEventListener {

--- a/android/src/main/java/com/nami/reactlibrary/NamiManagerBridge.kt
+++ b/android/src/main/java/com/nami/reactlibrary/NamiManagerBridge.kt
@@ -1,8 +1,6 @@
 package com.nami.reactlibrary
 
-import android.util.Log
 import com.facebook.react.bridge.*
-import com.facebook.react.modules.core.DeviceEventManagerModule
 import com.namiml.Nami
 
 class NamiManagerBridgeModule(reactContext: ReactApplicationContext) :

--- a/android/src/main/java/com/nami/reactlibrary/NamiPaywallManagerBridgeModule.kt
+++ b/android/src/main/java/com/nami/reactlibrary/NamiPaywallManagerBridgeModule.kt
@@ -27,12 +27,6 @@ class NamiPaywallManagerBridgeModule(reactContext: ReactApplicationContext) :
         var productId: String? = null
         var skuRefId: String? = null
         var typeString: String? = null
-        var purchaseSourceString: String? = null
-        var expiresDateInt: Int? = null
-        var purchaseDateInt: Int? = null
-
-        var expiresDate: Date? = null
-        var purchaseDate: Date? = null
 
         var skuType: NamiSKUType?
 
@@ -62,34 +56,6 @@ class NamiPaywallManagerBridgeModule(reactContext: ReactApplicationContext) :
             }
         }
 
-        if (dict.hasKey("purchaseSource")) {
-            purchaseSourceString = dict.getString("purchaseSource")
-        }
-
-        if (dict.hasKey("expiresDate")) {
-            expiresDateInt = dict.getInt("expiresDate")
-            expiresDate = Date(expiresDateInt * 1000L)
-        }
-        if (dict.hasKey("purchaseDate")) {
-            purchaseDateInt = dict.getInt("purchaseDate")
-            purchaseDate = Date(purchaseDateInt * 1000L)
-        }
-
-        val purchaseSource = when (purchaseSourceString) {
-            "CAMPAIGN" -> {
-                NamiPurchaseSource.CAMPAIGN
-            }
-            "MARKETPLACE" -> {
-                NamiPurchaseSource.MARKETPLACE
-            }
-            "UNKNOWN" -> {
-                NamiPurchaseSource.UNKNOWN
-            }
-            else -> {
-                NamiPurchaseSource.UNKNOWN
-            }
-        }
-
         if (productId != null && skuRefId != null) {
             val namiSku = NamiSKU.create(
                 skuRefId = skuRefId,
@@ -104,15 +70,11 @@ class NamiPaywallManagerBridgeModule(reactContext: ReactApplicationContext) :
                 if (dict.hasKey("orderId")) {
                     orderId = dict.getString("orderId")
                 }
-                Log.d(LOG_TAG, "$namiSku $purchaseToken $orderId $purchaseDateInt $purchaseDate")
+                Log.d(LOG_TAG, "$namiSku $purchaseToken $orderId")
 
-                if (namiSku != null && purchaseToken != null && orderId != null && purchaseDate != null) {
+                if (namiSku != null && purchaseToken != null && orderId != null) {
                     purchaseSuccess = NamiPurchaseSuccess.GooglePlay(
                         product = namiSku,
-                        expiresDate = expiresDate,
-                        purchaseDate = purchaseDate,
-                        purchaseSource = purchaseSource,
-                        description = null,
                         orderId = orderId,
                         purchaseToken = purchaseToken,
                     )
@@ -130,13 +92,9 @@ class NamiPaywallManagerBridgeModule(reactContext: ReactApplicationContext) :
                 if (dict.hasKey("marketplace")) {
                     marketplace = dict.getString("marketplace")
                 }
-                if (namiSku != null && receiptId != null && localizedPrice != null && userId != null && marketplace != null && purchaseDate != null) {
+                if (namiSku != null && receiptId != null && localizedPrice != null && userId != null && marketplace != null) {
                     purchaseSuccess = NamiPurchaseSuccess.Amazon(
                         product = namiSku,
-                        expiresDate = expiresDate,
-                        purchaseDate = purchaseDate,
-                        purchaseSource = purchaseSource,
-                        description = null,
                         receiptId = receiptId,
                         localizedPrice = localizedPrice,
                         userId = userId,
@@ -213,15 +171,13 @@ class NamiPaywallManagerBridgeModule(reactContext: ReactApplicationContext) :
 
     @ReactMethod
     fun registerDeeplinkActionHandler() {
-        NamiPaywallManager.registerDeepLinkHandler { activity , url ->
+        NamiPaywallManager.registerDeepLinkHandler { activity, url ->
             latestPaywallActivity = activity
             reactApplicationContext
                 .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter::class.java)
                 .emit("PaywallDeeplinkAction", url)
         }
-
     }
-
 
     @ReactMethod
     fun show() {

--- a/examples/Basic/App.tsx
+++ b/examples/Basic/App.tsx
@@ -62,18 +62,13 @@ const App = () => {
             product: sku,
             transactionID: '12345',
             originalTransactionID: '12345',
-            originalPurchaseDate: 1684823428,
-            purchaseDate: 1684823428,
             price: '120',
             currencyCode: 'USD',
-            locale: 'US',
           });
         } else if (Platform.OS === 'android') {
           if (Platform.constants.Manufacturer === 'Amazon') {
             NamiPaywallManager.buySkuCompleteAmazon({
               product: sku,
-              purchaseDate: 1684823428,
-              purchaseSource: 'CAMPAIGN',
               receiptId: '12345',
               localizedPrice: '120',
               userId: '12345',
@@ -82,8 +77,6 @@ const App = () => {
           } else {
             NamiPaywallManager.buySkuCompleteGooglePlay({
               product: sku,
-              purchaseDate: 1684823428,
-              purchaseSource: 'CAMPAIGN',
               purchaseToken:
                 'jolbnkpmojnpnjecgmphbmkc.AO-J1OznE4AIzyUvKFe1RSVkxw4KEtv0WfyL_tkzozOqnlSvIPsyQJBphCN80gwIMaex4EMII95rFCZhMCbVPZDc-y_VVhQU5Ddua1dLn8zV7ms_tdwoDmE',
               orderId: 'GPA.3317-0284-9993-42221',

--- a/examples/Basic/android/app/build.gradle
+++ b/examples/Basic/android/app/build.gradle
@@ -224,7 +224,7 @@ dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])
     implementation "com.facebook.react:react-native:+"  // From node_modules
     implementation 'com.github.jeziellago:compose-markdown:0.3.0'
-    implementation "com.namiml:sdk-android:3.1.16"
+    implementation "com.namiml:sdk-android:3.1.17"
 
     implementation project(':react-native-screens')
 

--- a/examples/Basic/config/index.ts
+++ b/examples/Basic/config/index.ts
@@ -7,8 +7,8 @@ export function getConfigObject() {
   switch (flavor) {
     case 'staging':
       return {
-        'appPlatformID-apple': '4a2f6dbf-e684-4d65-a4df-0488771c577d',
-        'appPlatformID-android': 'b7232eba-ff1d-4b7f-b8d0-55593b66c1d5',
+        'appPlatformID-apple': 'APPLE_STG_APP_PLATFORM_ID',
+        'appPlatformID-android': 'ANDROID_STG_APP_PLATFORM_ID',
         logLevel: 'DEBUG',
         namiCommands: ['useStagingAPI', 'useNamiWindow'],
         initialConfig: getInitialConfig(),

--- a/examples/Basic/config/index.ts
+++ b/examples/Basic/config/index.ts
@@ -7,8 +7,8 @@ export function getConfigObject() {
   switch (flavor) {
     case 'staging':
       return {
-        'appPlatformID-apple': 'APPLE_STG_APP_PLATFORM_ID',
-        'appPlatformID-android': 'ANDROID_STG_APP_PLATFORM_ID',
+        'appPlatformID-apple': '4a2f6dbf-e684-4d65-a4df-0488771c577d',
+        'appPlatformID-android': 'b7232eba-ff1d-4b7f-b8d0-55593b66c1d5',
         logLevel: 'DEBUG',
         namiCommands: ['useStagingAPI', 'useNamiWindow'],
         initialConfig: getInitialConfig(),

--- a/examples/TestNamiTV/App.tsx
+++ b/examples/TestNamiTV/App.tsx
@@ -59,18 +59,13 @@ const App = () => {
             product: sku,
             transactionID: '12345',
             originalTransactionID: '12345',
-            originalPurchaseDate: 1684823428,
-            purchaseDate: 1684823428,
             price: '120',
             currencyCode: 'USD',
-            locale: 'US',
           });
         } else if (Platform.OS === 'android') {
           if (Platform.constants.Manufacturer === 'Amazon') {
             NamiPaywallManager.buySkuCompleteAmazon({
               product: sku,
-              purchaseDate: 1684823428,
-              purchaseSource: 'CAMPAIGN',
               receiptId: '12345',
               localizedPrice: '120',
               userId: '12345',
@@ -79,8 +74,6 @@ const App = () => {
           } else {
             NamiPaywallManager.buySkuCompleteGooglePlay({
               product: sku,
-              purchaseDate: 1684823428,
-              purchaseSource: 'CAMPAIGN',
               purchaseToken:
                 'jolbnkpmojnpnjecgmphbmkc.AO-J1OznE4AIzyUvKFe1RSVkxw4KEtv0WfyL_tkzozOqnlSvIPsyQJBphCN80gwIMaex4EMII95rFCZhMCbVPZDc-y_VVhQU5Ddua1dLn8zV7ms_tdwoDmE',
               orderId: 'GPA.3317-0284-9993-42221',

--- a/examples/TestNamiTV/android/app/build.gradle
+++ b/examples/TestNamiTV/android/app/build.gradle
@@ -227,8 +227,8 @@ dependencies {
     implementation "com.facebook.react:react-native:+"  // From node_modules
     implementation 'com.github.jeziellago:compose-markdown:0.3.0'
 
-    amazonImplementation "com.namiml:sdk-amazon:3.1.16"
-    playImplementation "com.namiml:sdk-android:3.1.16"
+    amazonImplementation "com.namiml:sdk-amazon:3.1.17"
+    playImplementation "com.namiml:sdk-android:3.1.17"
 
     if (enableHermes) {
         def hermesPath = "../../node_modules/hermes-engine/android/";

--- a/ios/Nami.m
+++ b/ios/Nami.m
@@ -50,7 +50,7 @@ RCT_EXPORT_METHOD(configure: (NSDictionary *)configDict completion: (RCTResponse
         }
 
         // Start commands with header iformation for Nami to let them know this is a React client.
-        NSMutableArray *namiCommandStrings = [NSMutableArray arrayWithArray:@[@"extendedClientInfo:react-native:3.1.14"]];
+        NSMutableArray *namiCommandStrings = [NSMutableArray arrayWithArray:@[@"extendedClientInfo:react-native:3.1.17"]];
 
         // Add additional namiCommands app may have sent in.
         NSObject *appCommandStrings = configDict[@"namiCommands"];

--- a/ios/NamiPaywallManagerBridge.swift
+++ b/ios/NamiPaywallManagerBridge.swift
@@ -42,35 +42,24 @@ class RNNamiPaywallManager: RCTEventEmitter {
                 }
 
                 let namiSku = NamiSKU(namiId: namiId, storeId: storeId, skuType: namiSkuType)
+                let priceString = dict["price"] as? String ?? "0"
 
                 do {
-                    let dateFormatter = DateFormatter()
-                    dateFormatter.locale = .init(identifier: "en_US_POSIX")
-                    dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSZ"
-
-                    if
-                        let transactionID = dict["transactionID"] as? String,
-                        let originalTransactionID = dict["originalTransactionID"] as? String,
-                        let priceDecimal = Decimal(string: dict["price"] as! String),
-                        let currencyCode = dict["currencyCode"] as? String,
-                        let localeString = dict["locale"] as? String
+                    if let transactionID = dict["transactionID"] as? String,
+                       let originalTransactionID = dict["originalTransactionID"] as? String,
+                       let priceDecimal = Decimal(string: priceString),
+                       let currencyCode = dict["currencyCode"] as? String
                     {
-                        let expiresDate = Date(timeIntervalSince1970: dict["purchaseDate"] as! Double? ?? 0)
-                        let originalPurchaseDate = Date(timeIntervalSince1970: dict["originalPurchaseDate"] as! Double)
-                        let purchaseDate = Date(timeIntervalSince1970: dict["purchaseDate"] as! Double)
-                        let locale = Locale(identifier: localeString)
                         let purchaseSuccess = NamiPurchaseSuccess(
                             product: namiSku,
                             transactionID: transactionID,
                             originalTransactionID: originalTransactionID,
-                            originalPurchaseDate: originalPurchaseDate,
-                            purchaseDate: purchaseDate,
-                            expiresDate: expiresDate,
                             price: priceDecimal,
-                            currencyCode: currencyCode,
-                            locale: locale
+                            currencyCode: currencyCode
                         )
                         NamiPaywallManager.buySkuComplete(purchaseSuccess: purchaseSuccess)
+                    } else {
+                        print("RNNamiPaywallManager - buySkuComplete payload error \(dict)")
                     }
                 } catch {
                     print("RNNamiPaywallManager - buySkuComplete error - decoding JSON: \(error)")

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-nami-sdk",
-  "version": "3.1.14",
+  "version": "3.1.17",
   "description": "React Native Module for Nami - Easy subscriptions & in-app purchases, with powerful built-in paywalls and A/B testing.",
   "main": "index.ts",
   "types": "index.d.ts",

--- a/react-native-nami-sdk.podspec
+++ b/react-native-nami-sdk.podspec
@@ -20,7 +20,7 @@ Pod::Spec.new do |s|
   s.source_files = "ios/**/*.{h,m,swift}"
   s.requires_arc = true
 
-  s.dependency 'Nami', '3.1.15'
+  s.dependency 'Nami', '3.1.17'
   s.dependency 'React'
 
 end

--- a/src/NamiPaywallManager.d.ts
+++ b/src/NamiPaywallManager.d.ts
@@ -32,28 +32,18 @@ export type NamiPurchaseSuccessApple = {
   product: NamiSKU;
   transactionID: string;
   originalTransactionID: string;
-  originalPurchaseDate: number;
-  purchaseDate: number;
-  expiresDate?: number;
   price: string;
   currencyCode: string;
-  locale: string;
 };
 
 export type NamiPurchaseSuccessGooglePlay = {
   product: NamiSKU;
   orderId: string;
-  purchaseDate: number;
-  expiresDate?: number;
   purchaseToken: string;
-  purchaseSource: 'CAMPAIGN' | 'MARKETPLACE' | 'UNKNOWN';
 };
 
 export type NamiPurchaseSuccessAmazon = {
   product: NamiSKU;
-  purchaseDate: number;
-  expiresDate?: number;
-  purchaseSource: 'CAMPAIGN' | 'MARKETPLACE' | 'UNKNOWN';
   receiptId: string;
   localizedPrice: string;
   userId: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -228,33 +228,23 @@ export type NamiEntitlement = {
   relatedSkus: NamiSKU[];
 };
 
-// NamiPayWallManager
+// NamiPaywallManager
 export type NamiPurchaseSuccessApple = {
   product: NamiSKU;
   transactionID: string;
   originalTransactionID: string;
-  originalPurchaseDate: number;
-  purchaseDate: number;
-  expiresDate?: number;
   price: string;
   currencyCode: string;
-  locale: string;
 };
 
 export type NamiPurchaseSuccessGooglePlay = {
   product: NamiSKU;
   orderId: string;
-  purchaseDate: number;
-  expiresDate?: number;
   purchaseToken: string;
-  purchaseSource: 'CAMPAIGN' | 'MARKETPLACE' | 'UNKNOWN';
 };
 
 export type NamiPurchaseSuccessAmazon = {
   product: NamiSKU;
-  purchaseDate: number;
-  expiresDate?: number;
-  purchaseSource: 'CAMPAIGN' | 'MARKETPLACE' | 'UNKNOWN';
   receiptId: string;
   localizedPrice: string;
   userId: string;


### PR DESCRIPTION
# v3.1.17 (Nov 1, 2023)

Jumping version forward to 3.1.17 to align with native dependencies.

## Enhancements
- Simply NamiPurchaseSuccess objects to require fewer features in order to call `NamiPaywallManager.buySkuComplete`

## Updated Native SDK Dependencies
- Apple SDK v3.1.17- [Release Notes](https://github.com/namiml/nami-apple/wiki/Nami-SDK-Stable-Releases#v3117-nov-1-2023)
- Android SDK v3.1.17- [Release Notes](https://github.com/namiml/nami-android/wiki/Nami-SDK-Stable-Releases#v3117-nov-1-2023)