### PR TITLE
3.1.18

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -84,7 +84,7 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
 
     implementation 'com.github.jeziellago:compose-markdown:0.3.0'
-    compileOnly "com.namiml:sdk-amazon:3.1.18-beta.01"
+    compileOnly "com.namiml:sdk-amazon:3.1.17"
 
     implementation 'com.facebook.react:react-native:+'  // From node_modules
     coreLibraryDesugaring "com.android.tools:desugar_jdk_libs:1.1.5"

--- a/android/src/main/java/com/nami/reactlibrary/NamiBridgeModule.kt
+++ b/android/src/main/java/com/nami/reactlibrary/NamiBridgeModule.kt
@@ -106,7 +106,7 @@ class NamiBridgeModule(reactContext: ReactApplicationContext) :
             } else {
                 Arguments.createArray()
             }
-        val settingsList = mutableListOf("extendedClientInfo:react-native:3.1.18-beta.1")
+        val settingsList = mutableListOf("extendedClientInfo:react-native:3.1.18")
         namiCommandsReact?.toArrayList()?.filterIsInstance<String>()?.let { commandsFromReact ->
             settingsList.addAll(commandsFromReact)
         }

--- a/examples/Basic/android/app/build.gradle
+++ b/examples/Basic/android/app/build.gradle
@@ -224,7 +224,7 @@ dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])
     implementation "com.facebook.react:react-native:+"  // From node_modules
     implementation 'com.github.jeziellago:compose-markdown:0.3.0'
-    implementation "com.namiml:sdk-android:3.1.18-beta.01"
+    implementation "com.namiml:sdk-android:3.1.17"
 
     implementation project(':react-native-screens')
 

--- a/examples/TestNamiTV/android/app/build.gradle
+++ b/examples/TestNamiTV/android/app/build.gradle
@@ -227,8 +227,8 @@ dependencies {
     implementation "com.facebook.react:react-native:+"  // From node_modules
     implementation 'com.github.jeziellago:compose-markdown:0.3.0'
 
-    amazonImplementation "com.namiml:sdk-amazon:3.1.18-beta.01"
-    playImplementation "com.namiml:sdk-android:3.1.18-beta.01"
+    amazonImplementation "com.namiml:sdk-amazon:3.1.17"
+    playImplementation "com.namiml:sdk-android:3.1.17"
 
     if (enableHermes) {
         def hermesPath = "../../node_modules/hermes-engine/android/";

--- a/ios/Nami.m
+++ b/ios/Nami.m
@@ -50,7 +50,7 @@ RCT_EXPORT_METHOD(configure: (NSDictionary *)configDict completion: (RCTResponse
         }
 
         // Start commands with header iformation for Nami to let them know this is a React client.
-        NSMutableArray *namiCommandStrings = [NSMutableArray arrayWithArray:@[@"extendedClientInfo:react-native:3.1.18-beta.1"]];
+        NSMutableArray *namiCommandStrings = [NSMutableArray arrayWithArray:@[@"extendedClientInfo:react-native:3.1.18"]];
 
         // Add additional namiCommands app may have sent in.
         NSObject *appCommandStrings = configDict[@"namiCommands"];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-nami-sdk",
-  "version": "3.1.18-beta.1",
+  "version": "3.1.18",
   "description": "React Native Module for Nami - Easy subscriptions & in-app purchases, with powerful built-in paywalls and A/B testing.",
   "main": "index.ts",
   "types": "index.d.ts",

--- a/react-native-nami-sdk.podspec
+++ b/react-native-nami-sdk.podspec
@@ -20,7 +20,7 @@ Pod::Spec.new do |s|
   s.source_files = "ios/**/*.{h,m,swift}"
   s.requires_arc = true
 
-  s.dependency 'Nami', '3.1.18-beta.01'
+  s.dependency 'Nami', '3.1.18'
   s.dependency 'React'
 
 end


### PR DESCRIPTION
# v3.1.18 (Nov 7, 2023)

## Bug Fixes
- Fix issue with promotional eligibility key for tvOS paywalls

## Updated Native SDK Dependencies
- Apple SDK v3.1.18- [Release Notes](https://github.com/namiml/nami-apple/wiki/Nami-SDK-Stable-Releases#v3118-nov-2023)