### PR TITLE
3.1.21-beta.4

### DIFF
--- a/android/src/main/java/com/nami/reactlibrary/NamiBridgeModule.kt
+++ b/android/src/main/java/com/nami/reactlibrary/NamiBridgeModule.kt
@@ -106,7 +106,7 @@ class NamiBridgeModule(reactContext: ReactApplicationContext) :
             } else {
                 Arguments.createArray()
             }
-        val settingsList = mutableListOf("extendedClientInfo:react-native:3.1.21-beta.3")
+        val settingsList = mutableListOf("extendedClientInfo:react-native:3.1.21-beta.4")
         namiCommandsReact?.toArrayList()?.filterIsInstance<String>()?.let { commandsFromReact ->
             settingsList.addAll(commandsFromReact)
         }

--- a/ios/Nami.m
+++ b/ios/Nami.m
@@ -50,7 +50,7 @@ RCT_EXPORT_METHOD(configure: (NSDictionary *)configDict completion: (RCTResponse
         }
 
         // Start commands with header iformation for Nami to let them know this is a React client.
-        NSMutableArray *namiCommandStrings = [NSMutableArray arrayWithArray:@[@"extendedClientInfo:react-native:3.1.21-beta.3"]];
+        NSMutableArray *namiCommandStrings = [NSMutableArray arrayWithArray:@[@"extendedClientInfo:react-native:3.1.21-beta.4"]];
 
         // Add additional namiCommands app may have sent in.
         NSObject *appCommandStrings = configDict[@"namiCommands"];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-nami-sdk",
-  "version": "3.1.21-beta.3",
+  "version": "3.1.21-beta.4",
   "description": "React Native Module for Nami - Easy subscriptions & in-app purchases, with powerful built-in paywalls and A/B testing.",
   "main": "index.ts",
   "types": "index.d.ts",

--- a/react-native-nami-sdk.podspec
+++ b/react-native-nami-sdk.podspec
@@ -20,7 +20,7 @@ Pod::Spec.new do |s|
   s.source_files = "ios/**/*.{h,m,swift}"
   s.requires_arc = true
 
-  s.dependency 'Nami', '3.1.21-beta.02'
+  s.dependency 'Nami', '3.1.21-beta.03'
   s.dependency 'React'
 
 end


### PR DESCRIPTION
# v3.1.21-beta.4 (Dec 3, 2023)

## Native SDK Dependencies
- Apple SDK v3.1.21-beta.03 [Release Notes](https://github.com/namiml/nami-apple/wiki/Nami-SDK-Early-Access-Releases#v3121-beta03-dec-3-2023)