### PR TITLE
3.1.28

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-nami-sdk",
-  "version": "3.1.28-beta.1",
+  "version": "3.1.28",
   "description": "React Native Module for Nami - Easy subscriptions & in-app purchases, with powerful built-in paywalls and A/B testing.",
   "main": "index.ts",
   "types": "index.d.ts",

--- a/react-native-nami-sdk.podspec
+++ b/react-native-nami-sdk.podspec
@@ -20,7 +20,7 @@ Pod::Spec.new do |s|
   s.source_files = "ios/**/*.{h,m,swift}"
   s.requires_arc = true
 
-  s.dependency 'Nami', '3.1.28-beta.02'
+  s.dependency 'Nami', '3.1.28'
   s.dependency 'React'
 
 end


### PR DESCRIPTION
# v3.1.28 (Jan 12, 2024)

## Updated Native SDK Dependencies
- Apple SDK v3.1.28- [Release Notes](https://github.com/namiml/nami-apple/wiki/Nami-SDK-Stable-Releases#v3128-jan-12-2024)

## Unchanged Native SDK Dependencies
- Android SDK v3.1.24- [Release Notes](https://github.com/namiml/nami-android/wiki/Nami-SDK-Stable-Releases#v3124-jan-9-2024)
