### PR TITLE
Fix custom object issue in android bridge

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-nami-sdk",
-  "version": "3.2.2",
+  "version": "3.2.2-2",
   "description": "React Native Module for Nami - Easy subscriptions & in-app purchases, with powerful built-in paywalls and A/B testing.",
   "main": "index.ts",
   "types": "index.d.ts",


### PR DESCRIPTION
A customObject passed into PaywallLaunchContext was not getting converted properly from ReadableMap to MutableMap when passed over to the native Android layer, resulting in a crash.

Fixed the crash, and wrapped the conversion step in an exception handler.