### PR TITLE
NC-5315: add missing fields in NamiCampaign and NamiPurchase

### DIFF
--- a/examples/Basic/index.js
+++ b/examples/Basic/index.js
@@ -56,6 +56,24 @@ const Root = () => {
 
   }, []);
 
+  useEffect(() => {
+    async function configureNami() {
+      checkSdkConfigured();
+
+      const result = await Nami.configure(configDict);
+      if(result.success){
+        setIsConfigurationComplete(true);
+        checkSdkConfigured();
+      }
+  
+      initStoreConnection();
+  
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
+      return () => {};
+    }
+    configureNami();
+  }, []);
+
   return isConfigurationComplete ? <App /> : <View />;
 };
 

--- a/examples/TestNamiTV/index.js
+++ b/examples/TestNamiTV/index.js
@@ -20,18 +20,22 @@ export const getAmazonProducts = () => {
 
 const Root = () => {
   const [isConfigurationComplete, setIsConfigurationComplete] = useState();
-  useEffect(async () => {
-    const result = await Nami.configure(configDict);
-    if(result.success){
-      setIsConfigurationComplete(true);
-
-      if (Platform.constants.Manufacturer === 'Amazon') {
-        NamiPaywallManager.setProductDetails(getAmazonProducts(), false);
+  useEffect(() => {
+    async function configureNami() {
+      const result = await Nami.configure(configDict);
+      if(result.success){
+        setIsConfigurationComplete(true);
+  
+        if (Platform.constants.Manufacturer === 'Amazon') {
+          NamiPaywallManager.setProductDetails(getAmazonProducts(), false);
+        }
       }
+  
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
+      return () => {};
+  
     }
-
-    // eslint-disable-next-line @typescript-eslint/no-empty-function
-    return () => {};
+    configureNami();
   }, []);
 
   return isConfigurationComplete ? <App /> : <View />;

--- a/index.ts
+++ b/index.ts
@@ -6,5 +6,4 @@ export { NamiEntitlementManager } from './src/NamiEntitlementManager';
 export { NamiManager } from './src/NamiManager';
 export { NamiPurchaseManager } from './src/NamiPurchaseManager';
 export { NamiPaywallManager } from './src/NamiPaywallManager';
-export { NamiSKU } from './src/types';
 export * from './src/types';

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -47,13 +47,20 @@ export type AppleProduct = {
 export type GoogleProduct = {};
 export type AmazonProduct = {};
 export type NamiCampaign = {
-    id: string;
+    name: string;
     rule: string;
     segment: string;
     paywall: string;
     type: NamiCampaignRuleType;
     value?: string | null;
+    form_factors: FormFactor[];
+    external_segment_id: string | null;
 };
+type FormFactor = {
+    form_factor: string;
+    supports_portrait: boolean;
+    supports_landscape: boolean;
+}
 export declare enum NamiCampaignRuleType {
     DEFAULT = "default",
     LABEL = "label",
@@ -158,6 +165,7 @@ export type NamiPurchase = {
     sku?: NamiSKU;
     skuId: string;
     transactionIdentifier?: string;
+    purchaseToken?: string;
     expires?: Date;
     purchaseInitiatedTimestamp: Date;
     purchaseSource?: 'CAMPAIGN' | 'MARKETPLACE' | 'UNKNOWN';

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -53,13 +53,13 @@ export type NamiCampaign = {
     paywall: string;
     type: NamiCampaignRuleType;
     value?: string | null;
-    form_factors: FormFactor[];
+    form_factors: NamiFormFactor[];
     external_segment_id: string | null;
 };
-type FormFactor = {
+type NamiFormFactor = {
     form_factor: string;
-    supports_portrait: boolean;
-    supports_landscape: boolean;
+    supports_portrait?: boolean;
+    supports_landscape?: boolean;
 }
 export declare enum NamiCampaignRuleType {
     DEFAULT = "default",

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -54,7 +54,7 @@ export type NamiCampaign = {
     type: NamiCampaignRuleType;
     value?: string | null;
     form_factors: NamiFormFactor[];
-    external_segment_id: string | null;
+    external_segment: string | null;
 };
 type NamiFormFactor = {
     form_factor: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -174,7 +174,7 @@ type NamiFormFactor = {
   form_factor?: string;
   supports_portrait?: boolean;
   supports_landscape?: boolean;
-}
+};
 
 export enum LaunchCampaignError {
   DEFAULT_CAMPAIGN_NOT_FOUND = 0,

--- a/src/types.ts
+++ b/src/types.ts
@@ -159,7 +159,7 @@ export type NamiCampaign = {
   paywall: string;
   type: NamiCampaignRuleType;
   value?: string | null;
-  form_factors: FormFactor[];
+  form_factors: NamiFormFactor[];
   external_segment_id: string | null;
 };
 
@@ -170,10 +170,10 @@ export enum NamiCampaignRuleType {
   URL = 'url',
 }
 
-type FormFactor = {
-  form_factor: string;
-  supports_portrait: boolean;
-  supports_landscape: boolean;
+type NamiFormFactor = {
+  form_factor?: string;
+  supports_portrait?: boolean;
+  supports_landscape?: boolean;
 }
 
 export enum LaunchCampaignError {

--- a/src/types.ts
+++ b/src/types.ts
@@ -160,7 +160,7 @@ export type NamiCampaign = {
   type: NamiCampaignRuleType;
   value?: string | null;
   form_factors: NamiFormFactor[];
-  external_segment_id: string | null;
+  external_segment: string | null;
 };
 
 export enum NamiCampaignRuleType {

--- a/src/types.ts
+++ b/src/types.ts
@@ -153,12 +153,14 @@ export type AmazonProduct = {};
 
 // NamiCampaignManager
 export type NamiCampaign = {
-  id: string;
+  name: string;
   rule: string;
   segment: string;
   paywall: string;
   type: NamiCampaignRuleType;
   value?: string | null;
+  form_factors: FormFactor[];
+  external_segment_id: string | null;
 };
 
 export enum NamiCampaignRuleType {
@@ -166,6 +168,12 @@ export enum NamiCampaignRuleType {
   LABEL = 'label',
   UNKNOWN = 'unknown',
   URL = 'url',
+}
+
+type FormFactor = {
+  form_factor: string;
+  supports_portrait: boolean;
+  supports_landscape: boolean;
 }
 
 export enum LaunchCampaignError {
@@ -295,6 +303,7 @@ export type NamiPurchase = {
   sku?: NamiSKU;
   skuId: string;
   transactionIdentifier?: string;
+  purchaseToken?: string;
   expires?: Date;
   purchaseInitiatedTimestamp: Date;
   purchaseSource?: 'CAMPAIGN' | 'MARKETPLACE' | 'UNKNOWN';


### PR DESCRIPTION
-  NamiCampaign: 
    - Remove `id` and add `name`
    - Add `form_factors` and `external_segment_id`
- NamiPurchase: 
    - Add `purchaseToken`

@namidan In iOS and Android's `NamiCampaign` type,  I have seen they are using `external_segment`, but we are getting `external_segment_id` from API response. Should we need to change from `external_segment_id` to `external_segment` ?
