### PR TITLE
3.2.2-3

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -85,8 +85,8 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
 
-    playImplementation "com.namiml:sdk-android:3.2.2"
-    amazonImplementation "com.namiml:sdk-amazon:3.2.2"
+    playImplementation "com.namiml:sdk-android:3.2.2.1"
+    amazonImplementation "com.namiml:sdk-amazon:3.2.2.1"
 
     implementation "com.facebook.react:react-native:+"  // From node_modules
     coreLibraryDesugaring "com.android.tools:desugar_jdk_libs:1.1.5"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-nami-sdk",
-  "version": "3.2.2-2",
+  "version": "3.2.2-3",
   "description": "React Native Module for Nami - Easy subscriptions & in-app purchases, with powerful built-in paywalls and A/B testing.",
   "main": "index.ts",
   "types": "index.d.ts",


### PR DESCRIPTION
# v3.2.2-3 (Aug 13, 2024)

## Updated Native SDK Dependencies
- Android SDK v3.2.2.1- [Release Notes](https://github.com/namiml/nami-android/wiki/Nami-SDK-Stable-Releases#3221-aug-13-2024)