### PR TITLE
Chore/android version bump 3.2.3.1

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -37,7 +37,7 @@ android {
     buildToolsVersion safeExtGet('buildToolsVersion', DEFAULT_BUILD_TOOLS_VERSION)
     defaultConfig {
         minSdkVersion 22
-        targetSdkVersion 33
+        targetSdkVersion 34
         versionCode 1
         versionName "1.0"
     }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -85,8 +85,8 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
 
-    playImplementation "com.namiml:sdk-android:3.2.3"
-    amazonImplementation "com.namiml:sdk-amazon:3.2.3"
+    playImplementation "com.namiml:sdk-android:3.2.3.1"
+    amazonImplementation "com.namiml:sdk-amazon:3.2.3.1"
 
     implementation "com.facebook.react:react-native:+"  // From node_modules
     coreLibraryDesugaring "com.android.tools:desugar_jdk_libs:1.1.5"

--- a/examples/Basic/android/build.gradle
+++ b/examples/Basic/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         buildToolsVersion = "34.0.0"
         minSdkVersion = 22
         compileSdkVersion = 34
-        targetSdkVersion = 33
+        targetSdkVersion = 34
         kotlin_version = '1.8.20'
     }
 

--- a/examples/TestNamiTV/android/build.gradle
+++ b/examples/TestNamiTV/android/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         compileSdkVersion = 34
 //        ndkVersion = "25.1.8937393"
         kotlin_version = '1.8.20'
-        targetSdkVersion = 33
+        targetSdkVersion = 34
     }
 
     repositories {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-nami-sdk",
-  "version": "3.2.3",
+  "version": "3.2.3-2",
   "description": "React Native Module for Nami - Easy subscriptions & in-app purchases, with powerful built-in paywalls and A/B testing.",
   "main": "index.ts",
   "types": "index.d.ts",


### PR DESCRIPTION
# v3.2.3.1 (Aug 30, 2024)

## Maintenance
- Bump `targetSdkVersion` to `34` for bridge and sample apps
- 
## Updated Native SDK Dependencies

- Android SDK v3.2.3.1- [Release Notes](https://github.com/namiml/nami-android/wiki/Nami-SDK-Stable-Releases#3231-aug-30-2024)
