### PR TITLE
3.2.4

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -85,8 +85,8 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
 
-    playImplementation "com.namiml:sdk-android:3.2.4-beta.01"
-    amazonImplementation "com.namiml:sdk-amazon:3.2.4-beta.01"
+    playImplementation "com.namiml:sdk-android:3.2.4"
+    amazonImplementation "com.namiml:sdk-amazon:3.2.4"
 
     implementation "com.facebook.react:react-native:+"  // From node_modules
     coreLibraryDesugaring "com.android.tools:desugar_jdk_libs:1.1.5"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-nami-sdk",
-  "version": "3.2.4-beta.1",
+  "version": "3.2.4",
   "description": "React Native Module for Nami - Easy subscriptions & in-app purchases, with powerful built-in paywalls and A/B testing.",
   "main": "index.ts",
   "types": "index.d.ts",

--- a/react-native-nami-sdk.podspec
+++ b/react-native-nami-sdk.podspec
@@ -20,7 +20,7 @@ Pod::Spec.new do |s|
   s.source_files = "ios/**/*.{h,m,swift}"
   s.requires_arc = true
 
-  s.dependency 'Nami', '3.2.4-beta.01'
+  s.dependency 'Nami', '3.2.4'
   s.dependency 'React'
 
 end


### PR DESCRIPTION
# v3.2.4 (Sep 26, 2024)

## Bugfixes
- Amazon FireTV: Honor `allowOffers` flag in `NamiPaywallManager.setProductsDetails`

## Updated Native SDK Dependencies

- Apple SDK v3.2.4- [Release Notes](https://github.com/namiml/nami-apple/wiki/Nami-SDK-Stable-Releases#324-sep-26-2024)
- Android SDK v3.2.4- [Release Notes](https://github.com/namiml/nami-android/wiki/Nami-SDK-Stable-Releases#324-sep-26-2024)