### PR TITLE
3.2.8

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -85,8 +85,8 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
 
-    playImplementation "com.namiml:sdk-android:3.2.7"
-    amazonImplementation "com.namiml:sdk-amazon:3.2.7"
+    playImplementation "com.namiml:sdk-android:3.2.8"
+    amazonImplementation "com.namiml:sdk-amazon:3.2.8"
 
     implementation "com.facebook.react:react-native:+"  // From node_modules
     coreLibraryDesugaring "com.android.tools:desugar_jdk_libs:1.1.5"

--- a/android/src/main/java/com/nami/reactlibrary/NamiBridgeModule.kt
+++ b/android/src/main/java/com/nami/reactlibrary/NamiBridgeModule.kt
@@ -106,7 +106,7 @@ class NamiBridgeModule(reactContext: ReactApplicationContext) :
             } else {
                 Arguments.createArray()
             }
-        val settingsList = mutableListOf("extendedClientInfo:react-native:3.2.7")
+        val settingsList = mutableListOf("extendedClientInfo:react-native:3.2.8")
         namiCommandsReact?.toArrayList()?.filterIsInstance<String>()?.let { commandsFromReact ->
             settingsList.addAll(commandsFromReact)
         }

--- a/android/src/main/java/com/nami/reactlibrary/NamiUtil.kt
+++ b/android/src/main/java/com/nami/reactlibrary/NamiUtil.kt
@@ -84,6 +84,10 @@ fun NamiSKU.toSkuDict(): WritableMap {
         productDict.putString("promoId", this.promoId)
     }
 
+    if (this.promoOfferToken != null) {
+        productDict.putString("promoToken", this.promoOfferToken)
+    }
+
     return productDict
 }
 

--- a/ios/Nami.m
+++ b/ios/Nami.m
@@ -50,7 +50,7 @@ RCT_EXPORT_METHOD(configure: (NSDictionary *)configDict completion: (RCTResponse
         }
 
         // Start commands with header iformation for Nami to let them know this is a React client.
-        NSMutableArray *namiCommandStrings = [NSMutableArray arrayWithArray:@[@"extendedClientInfo:react-native:3.2.7"]];
+        NSMutableArray *namiCommandStrings = [NSMutableArray arrayWithArray:@[@"extendedClientInfo:react-native:3.2.8"]];
 
         // Add additional namiCommands app may have sent in.
         NSObject *appCommandStrings = configDict[@"namiCommands"];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-nami-sdk",
-  "version": "3.2.7",
+  "version": "3.2.8",
   "description": "React Native Module for Nami - Easy subscriptions & in-app purchases, with powerful built-in paywalls and A/B testing.",
   "main": "index.ts",
   "types": "index.d.ts",

--- a/react-native-nami-sdk.podspec
+++ b/react-native-nami-sdk.podspec
@@ -20,7 +20,7 @@ Pod::Spec.new do |s|
   s.source_files = "ios/**/*.{h,m,swift}"
   s.requires_arc = true
 
-  s.dependency 'Nami', '3.2.7'
+  s.dependency 'Nami', '3.2.8'
   s.dependency 'React'
 
 end


### PR DESCRIPTION
# v3.2.8 (Nov 7, 2024)

## Updated Native SDK Dependencies

- Apple SDK v3.2.8- [Release Notes](https://github.com/namiml/nami-apple/wiki/Nami-SDK-Stable-Releases#328-nov-7-2024)
- Android SDK v3.2.8- [Release Notes](https://github.com/namiml/nami-android/wiki/Nami-SDK-Stable-Releases#328-nov-7-2024)
