### PR TITLE
3.2.8-1

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -181,7 +181,7 @@ jobs:
 
       - name: Upload artifacts
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: detox-artifacts
           path: artifacts
@@ -329,7 +329,7 @@ jobs:
 
       - name: Upload artifacts
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: detox-artifacts
           path: artifacts

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -91,7 +91,7 @@ jobs:
           npx eslint . --ext .js,.jsx,.ts,.tsx
         working-directory: source/examples/TestNamiTV
   e2e-ios:
-    runs-on: macos-12
+    runs-on: macos-13
     env:
       DETOX_CONFIGURATION: ios.sim.release
 
@@ -186,7 +186,7 @@ jobs:
           name: detox-artifacts
           path: artifacts
   e2e-android:
-    runs-on: macos-12
+    runs-on: macos-13
     env:
       DETOX_CONFIGURATION: android.emu.release
 

--- a/examples/Basic/android/build.gradle
+++ b/examples/Basic/android/build.gradle
@@ -3,7 +3,7 @@
 buildscript {
     ext {
         buildToolsVersion = "34.0.0"
-        minSdkVersion = 22
+        minSdkVersion = 24
         compileSdkVersion = 34
         targetSdkVersion = 34
         kotlin_version = '1.8.20'

--- a/examples/Basic/package.json
+++ b/examples/Basic/package.json
@@ -44,7 +44,7 @@
     "@types/react": "^18.2.6",
     "@types/react-test-renderer": "^18.0.0",
     "babel-jest": "^29.6.3",
-    "detox": "20.9.1",
+    "detox": "20.32.0",
     "eslint": "^8.19.0",
     "jest": "^29.6.3",
     "metro-react-native-babel-preset": "^0.77.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-nami-sdk",
-  "version": "3.2.8",
+  "version": "3.2.8-1",
   "description": "React Native Module for Nami - Easy subscriptions & in-app purchases, with powerful built-in paywalls and A/B testing.",
   "main": "index.ts",
   "types": "index.d.ts",

--- a/react-native-nami-sdk.podspec
+++ b/react-native-nami-sdk.podspec
@@ -20,7 +20,7 @@ Pod::Spec.new do |s|
   s.source_files = "ios/**/*.{h,m,swift}"
   s.requires_arc = true
 
-  s.dependency 'Nami', '3.2.8'
+  s.dependency 'Nami', '3.2.9'
   s.dependency 'React'
 
 end


### PR DESCRIPTION
# v3.2.8-1 (Jan 23, 2025)

## Updated Native SDK Dependencies

- Apple SDK v3.2.9- [Release Notes](https://github.com/namiml/nami-apple/wiki/Nami-SDK-Stable-Releases#329-jan-13-2025)
