### PR TITLE
Update README.md to remove sudo when installing Cocoapods

### DIFF
--- a/examples/Basic/README.md
+++ b/examples/Basic/README.md
@@ -18,7 +18,7 @@ brew install yarn
 
 **iOS Setup**
 
-1. Install CocoaPods -> `sudo brew install cocoapods`
+1. Install CocoaPods -> `brew install cocoapods`
 2. `cd ios && rm -rf Pods Podfile.lock && RCT_NEW_ARCH_ENABLED=0 SWIFT_VERSION=5 pod install`
 3. Either run `yarn run ios` or `open Basic.xcworkspace` and build in Xcode.
 


### PR DESCRIPTION
Brew now automatically prevents installation of a package when run as root, so installing Cocoapods should not be run using sudo.