### PR TITLE
3.2.11

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -86,7 +86,7 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
 
     playImplementation "com.namiml:sdk-android:3.2.11"
-    amazonImplementation "com.namiml:sdk-amazon:3.2.12"
+    amazonImplementation "com.namiml:sdk-amazon:3.2.11"
 
     implementation "com.facebook.react:react-native:+"  // From node_modules
     coreLibraryDesugaring "com.android.tools:desugar_jdk_libs:1.1.5"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -85,8 +85,8 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
 
-    playImplementation "com.namiml:sdk-android:3.2.10"
-    amazonImplementation "com.namiml:sdk-amazon:3.2.10"
+    playImplementation "com.namiml:sdk-android:3.2.11"
+    amazonImplementation "com.namiml:sdk-amazon:3.2.12"
 
     implementation "com.facebook.react:react-native:+"  // From node_modules
     coreLibraryDesugaring "com.android.tools:desugar_jdk_libs:1.1.5"

--- a/android/src/main/java/com/nami/reactlibrary/NamiBridgeModule.kt
+++ b/android/src/main/java/com/nami/reactlibrary/NamiBridgeModule.kt
@@ -106,7 +106,7 @@ class NamiBridgeModule(reactContext: ReactApplicationContext) :
             } else {
                 Arguments.createArray()
             }
-        val settingsList = mutableListOf("extendedClientInfo:react-native:3.2.10")
+        val settingsList = mutableListOf("extendedClientInfo:react-native:3.2.11")
         namiCommandsReact?.toArrayList()?.filterIsInstance<String>()?.let { commandsFromReact ->
             settingsList.addAll(commandsFromReact)
         }

--- a/ios/Nami.m
+++ b/ios/Nami.m
@@ -50,7 +50,7 @@ RCT_EXPORT_METHOD(configure: (NSDictionary *)configDict completion: (RCTResponse
         }
 
         // Start commands with header iformation for Nami to let them know this is a React client.
-        NSMutableArray *namiCommandStrings = [NSMutableArray arrayWithArray:@[@"extendedClientInfo:react-native:3.2.10"]];
+        NSMutableArray *namiCommandStrings = [NSMutableArray arrayWithArray:@[@"extendedClientInfo:react-native:3.2.11"]];
 
         // Add additional namiCommands app may have sent in.
         NSObject *appCommandStrings = configDict[@"namiCommands"];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-nami-sdk",
-  "version": "3.2.10",
+  "version": "3.2.11",
   "description": "React Native Module for Nami - Easy subscriptions & in-app purchases, with powerful built-in paywalls and A/B testing.",
   "main": "index.ts",
   "types": "index.d.ts",

--- a/react-native-nami-sdk.podspec
+++ b/react-native-nami-sdk.podspec
@@ -20,7 +20,7 @@ Pod::Spec.new do |s|
   s.source_files = "ios/**/*.{h,m,swift}"
   s.requires_arc = true
 
-  s.dependency 'Nami', '3.2.10'
+  s.dependency 'Nami', '3.2.11'
   s.dependency 'React'
 
 end


### PR DESCRIPTION
# v3.2.11 (May 23, 2025)

## Updated Native SDK Dependencies

- Apple SDK v3.2.11- [Release Notes](https://github.com/namiml/nami-apple/wiki/Nami-SDK-Stable-Releases#3211-may-22-2025)
- Android SDK v3.2.11- [Release Notes](https://github.com/namiml/nami-android/wiki/Nami-SDK-Stable-Releases#3211-may-22-2025)
