### PR TITLE
3.3.0-2

### DIFF
--- a/.github/workflows/app_stg.yaml
+++ b/.github/workflows/app_stg.yaml
@@ -369,8 +369,8 @@ jobs:
 
       - name: Apply Patches
         run: |
-          patch -p0 < *.patch
-        working-directory: source/examples/TestNamiTV/patches
+          patch -p0 < patches/*.patch
+        working-directory: source/examples/TestNamiTV
 
       - name: Build resolve Swift dependencies
         run: |

--- a/examples/Basic/package.json
+++ b/examples/Basic/package.json
@@ -40,7 +40,7 @@
     "react-native": "0.75.0",
     "react-native-iap": "12.16.0",
     "react-native-logs": "^5.1.0",
-    "react-native-nami-sdk": "file:../../react-native-nami-sdk-3.3.0-1.tgz",
+    "react-native-nami-sdk": "file:../../react-native-nami-sdk-3.3.0-2.tgz",
     "react-native-permissions": "^5.4.1",
     "react-native-reanimated": "^3.18.0",
     "react-native-safe-area-context": "^4.10.7",

--- a/examples/TestNamiTV/package.json
+++ b/examples/TestNamiTV/package.json
@@ -38,7 +38,7 @@
     "react-native": "npm:react-native-tvos@0.75.4-0",
     "react-native-iap": "12.16.0",
     "react-native-logs": "^5.1.0",
-    "react-native-nami-sdk": "file:../../react-native-nami-sdk-3.3.0-1.tgz",
+    "react-native-nami-sdk": "file:../../react-native-nami-sdk-3.3.0-2.tgz",
     "react-native-reanimated": "^3.18.0",
     "react-native-safe-area-context": "^4.10.7",
     "react-native-screens": "4.11.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-nami-sdk",
-  "version": "3.3.0-1",
+  "version": "3.3.0-2",
   "description": "React Native Module for Nami - Easy subscriptions & in-app purchases, with powerful built-in paywalls and A/B testing.",
   "main": "index.ts",
   "types": "dist/index.d.ts",

--- a/react-native-nami-sdk.podspec
+++ b/react-native-nami-sdk.podspec
@@ -21,7 +21,7 @@ Pod::Spec.new do |s|
   s.requires_arc  = true
   s.swift_version = '5.0'  # or your supported version
 
-  s.dependency 'Nami', '3.3.0.2'
+  s.dependency 'Nami', '3.3.0.3'
   s.dependency 'React'
 
   s.pod_target_xcconfig = {


### PR DESCRIPTION
# v3.3.0-2 (Jul 11, 2025)

## Updates Native Dependencies

- Apple SDK v3.3.0.3- [Release Notes](https://github.com/namiml/nami-apple/wiki/Nami-SDK-Stable-Releases#3303-jul-11-2025)
